### PR TITLE
Add component for filtering meteor swarm targets

### DIFF
--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Server._Hardlight.StationEvents.Events;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Components;
@@ -44,11 +45,14 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 
         component.NextWaveTime += TimeSpan.FromSeconds(component.WaveCooldown.Next(RobustRandom));
 
+        // Hardlight: filter by ValidMeteorSwarmComponent to prevent ships from being hit
+        var stations = _station.GetStations()
+            .FindAll(it => it.Valid && HasComp<ValidMeteorSwarmComponent>(it));
 
-        if (_station.GetStations().Count == 0)
+        if (stations.Count == 0)
             return;
 
-        var station = RobustRandom.Pick(_station.GetStations());
+        var station = RobustRandom.Pick(stations);
         if (_station.GetLargestGrid(Comp<StationDataComponent>(station)) is not { } grid)
             return;
 

--- a/Content.Server/_Hardlight/StationEvents/Events/ValidMeteorSwarmTarget.cs
+++ b/Content.Server/_Hardlight/StationEvents/Events/ValidMeteorSwarmTarget.cs
@@ -1,0 +1,6 @@
+﻿using Content.Server.StationEvents.Events;
+
+namespace Content.Server._Hardlight.StationEvents.Events;
+
+[RegisterComponent, Access(typeof(MeteorSwarmSystem))]
+public sealed partial class ValidMeteorSwarmComponent : Component;


### PR DESCRIPTION
adds a new `ValidMeteorSwarmComponent`, which must be present on any station in order for that station to be a valid target during a meteor swarm event. per discord discussion, this would only be used on the main station, not on player ships nor POIs.

i've only tested that this builds, I did not try using it in-game