### PR TITLE
Station pay disconnections, cvar

### DIFF
--- a/Content.Server/_Hardlight/CVars.cs
+++ b/Content.Server/_Hardlight/CVars.cs
@@ -1,0 +1,18 @@
+﻿using Robust.Shared.Configuration;
+
+namespace Content.Server._Hardlight;
+
+[CVarDefs]
+public sealed class HardlightCVars
+{
+    /// <summary>
+    /// How often station staff wages are paid.
+    /// </summary>
+    public static readonly CVarDef<int> StationPayDelay =
+        CVarDef.Create(
+            "station_pay.delay",
+            3600,
+            CVar.SERVERONLY,
+            "how often station staff wages are paid"
+        );
+}

--- a/Content.Server/_Hardlight/StationPay/StationPaySystem.cs
+++ b/Content.Server/_Hardlight/StationPay/StationPaySystem.cs
@@ -61,6 +61,7 @@ public sealed class StationPaySystem : EntitySystem
     // map of {Mind.OwnedEntity: lastPayoutTime} where lastPayoutTime was the round duration at time of payout
     // sorted in ascending order
     private readonly SortedSet<ScheduledPayout> _scheduledPayouts = [];
+    private readonly Dictionary<EntityUid, int> _disconnectedPlayers = new();
 
     public override void Initialize()
     {
@@ -77,22 +78,8 @@ public sealed class StationPaySystem : EntitySystem
         SubscribeLocalEvent<RoleAddedEvent>(OnRoleAddedEvent);
         SubscribeLocalEvent<RoleRemovedEvent>(OnRoleRemovedEvent);
 
-        /*
-         * TODO: account for disconnecting players
-         *
-         * when someone disconnects add them to a removal list with a timestamp 10 minutes in the future
-         *
-         * after that time they are removed from the scheduledpayout dict
-         *
-         * if they reconnect before that time they are removed from the disconnect tracker
-         *
-         * this allows for a grace period where if you happen to disconnect right before the hour you still get paid
-         *
-         * and if you disconnect and reconnect you still get paid
-         *
-         * we also don't have to do any complex bookkeeping
-         */
-        // SubscribeLocalEvent<MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<MindRemovedMessage>(OnMindRemoved);
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
@@ -115,6 +102,7 @@ public sealed class StationPaySystem : EntitySystem
         }
 
         _scheduledPayouts.Clear();
+        _disconnectedPlayers.Clear();
     }
 
     private bool GetJobForEntity(
@@ -165,6 +153,35 @@ public sealed class StationPaySystem : EntitySystem
         _scheduledPayouts.Remove(new ScheduledPayout(args.Mind.OwnedEntity.Value, 0));
     }
 
+    private void OnMindRemoved(ref MindRemovedMessage args)
+    {
+        var uid = args.Container.Owner;
+        if (!_scheduledPayouts.TryGetValue(new ScheduledPayout(uid, 0), out var payout))
+            return;
+
+        var now = (int)_gameTicker.RoundDuration().TotalSeconds;
+        var worked = now - payout.LastPayout;
+
+        _scheduledPayouts.Remove(payout);
+
+        if (worked > 0)
+        {
+            _disconnectedPlayers[uid] = worked;
+        }
+    }
+
+    private void OnMindAdded(ref MindAddedMessage args)
+    {
+        var uid = args.Container.Owner;
+        if (!_disconnectedPlayers.Remove(uid, out var timeWorked))
+            return;
+
+        // note: this will pay someone more than it should if `PaymentDelay` has changed while this
+        // player was logged out!
+        var now = (int)_gameTicker.RoundDuration().TotalSeconds;
+        _scheduledPayouts.Add(new ScheduledPayout(uid, now - timeWorked));
+    }
+
     private void PayoutFor(EntityUid uid, int secondsWorked)
     {
         // sanity check
@@ -192,9 +209,6 @@ public sealed class StationPaySystem : EntitySystem
         var rate = _jobPayoutRates[(ProtoId<JobPrototype>)jobId];
         var amount = employedTime * rate;
 
-        // TODO: deposit doesn't work on logged out players, and frontier's banksystem has no method for
-        //       doing a code-based deposit without a backing session (i.e. admin player)
-        //       therefore currently if you are logged out at payment time you just miss that hour...
         if (!TryComp<MindContainerComponent>(uid, out var mc)
             || !mc.HasMind
             || !TryComp<MindComponent>(mc.Mind.Value, out var mind)

--- a/Content.Server/_Hardlight/StationPay/StationPaySystem.cs
+++ b/Content.Server/_Hardlight/StationPay/StationPaySystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
 using JetBrains.Annotations;
+using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -47,6 +48,7 @@ internal sealed class ScheduledPayout(EntityUid uid, int lastPayout) : IComparab
 [UsedImplicitly]
 public sealed class StationPaySystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
@@ -54,12 +56,9 @@ public sealed class StationPaySystem : EntitySystem
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
 
-    // TODO: this should probably be a cvar
-    private const int PayoutDelay = 3600;
+    private int _payoutDelay = 3600;
 
-    private readonly Dictionary<ProtoId<JobPrototype>, int> _jobPayoutRates = new();
-    // map of {Mind.OwnedEntity: lastPayoutTime} where lastPayoutTime was the round duration at time of payout
-    // sorted in ascending order
+    private readonly Dictionary<ProtoId<JobPrototype>, int> _jobPayoutRateByHour = new();
     private readonly SortedSet<ScheduledPayout> _scheduledPayouts = [];
     private readonly Dictionary<EntityUid, int> _disconnectedPlayers = new();
 
@@ -70,16 +69,18 @@ public sealed class StationPaySystem : EntitySystem
         // Logger.GetSawmill(SawmillName).Level = LogLevel.Verbose;
         foreach (var proto in _prototypeManager.EnumeratePrototypes<StationPayPrototype>())
         {
-            _jobPayoutRates[proto.JobProto] = proto.PayPerHour;
+            _jobPayoutRateByHour[proto.JobProto] = proto.PayPerHour;
             Log.Debug($"loaded prototype: {proto.JobProto.Id} at {proto.PayPerHour}");
         }
+
+        Subs.CVar(_config, HardlightCVars.StationPayDelay, value => _payoutDelay = value, true);
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
         SubscribeLocalEvent<RoleAddedEvent>(OnRoleAddedEvent);
         SubscribeLocalEvent<RoleRemovedEvent>(OnRoleRemovedEvent);
 
-        SubscribeLocalEvent<MindAddedMessage>(OnMindAdded);
-        SubscribeLocalEvent<MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<PlayerDetachedEvent>(OnPlayerDetached);
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
@@ -112,7 +113,7 @@ public sealed class StationPaySystem : EntitySystem
         jobPrototype = null;
         if (TryComp<JobTrackingComponent>(uid, out var jtc)
             && jtc.Job is {} job
-            && _jobPayoutRates.ContainsKey(job))
+            && _jobPayoutRateByHour.ContainsKey(job))
         {
             jobPrototype = job;
         }
@@ -134,7 +135,7 @@ public sealed class StationPaySystem : EntitySystem
         }
 
         var now = (int)_gameTicker.RoundDuration().TotalSeconds;
-        Log.Info($"{ToPrettyString(uid)} joined with job {job.Value.Id}. Round time: {now}, payout at: {now + PayoutDelay}");
+        Log.Info($"{ToPrettyString(uid)} joined with job {job.Value.Id}. Round time: {now}, payout at: {now + _payoutDelay}");
 
         var wrapper = new ScheduledPayout(uid.Value, now);
         // as equality is determined solely by the uid and not the timestamp we can
@@ -151,11 +152,12 @@ public sealed class StationPaySystem : EntitySystem
         Log.Info($"Character {args.Mind.CharacterName}'s job was removed");
         // as above, since equality is determined solely by uid we can remove from the set this way
         _scheduledPayouts.Remove(new ScheduledPayout(args.Mind.OwnedEntity.Value, 0));
+        _disconnectedPlayers.Remove(args.Mind.OwnedEntity.Value);
     }
 
-    private void OnMindRemoved(ref MindRemovedMessage args)
+    private void OnPlayerDetached(PlayerDetachedEvent args)
     {
-        var uid = args.Container.Owner;
+        var uid = args.Entity;
         if (!_scheduledPayouts.TryGetValue(new ScheduledPayout(uid, 0), out var payout))
             return;
 
@@ -163,23 +165,20 @@ public sealed class StationPaySystem : EntitySystem
         var worked = now - payout.LastPayout;
 
         _scheduledPayouts.Remove(payout);
+        _disconnectedPlayers[uid] = worked;
 
-        if (worked > 0)
-        {
-            _disconnectedPlayers[uid] = worked;
-        }
+        Log.Info($"Player {args.Player.Name} detached with {worked} unpaid seconds of work time.");
     }
 
-    private void OnMindAdded(ref MindAddedMessage args)
+    private void OnPlayerAttached(PlayerAttachedEvent args)
     {
-        var uid = args.Container.Owner;
+        var uid = args.Entity;
         if (!_disconnectedPlayers.Remove(uid, out var timeWorked))
             return;
 
-        // note: this will pay someone more than it should if `PaymentDelay` has changed while this
-        // player was logged out!
         var now = (int)_gameTicker.RoundDuration().TotalSeconds;
         _scheduledPayouts.Add(new ScheduledPayout(uid, now - timeWorked));
+        Log.Info($"Player {args.Player.Name} attached with {timeWorked} unpaid seconds of work time restored.");
     }
 
     private void PayoutFor(EntityUid uid, int secondsWorked)
@@ -197,21 +196,18 @@ public sealed class StationPaySystem : EntitySystem
             return;
         }
 
-        var employedTime = (int)(secondsWorked / (double)PayoutDelay);
+        var unitRate = _jobPayoutRateByHour[(ProtoId<JobPrototype>)jobId] / 3600d;
+        var amount = (int)(secondsWorked * unitRate);
 
-        // this could in principle be 0 if someone joined right before round end
-        if (employedTime <= 0)
+        if (amount <= 0)
         {
-            Log.Warning($"Skipping payout for {ToPrettyString(uid)} due to employedTime <= 0 (secondsWorked: {secondsWorked})");
+            Log.Warning($"Skipping payout for {ToPrettyString(uid)} due to amount <= 0 (secondsWorked: {secondsWorked}, unitRate: {unitRate})");
             return;
         }
 
-        var rate = _jobPayoutRates[(ProtoId<JobPrototype>)jobId];
-        var amount = employedTime * rate;
-
         if (!TryComp<MindContainerComponent>(uid, out var mc)
             || !mc.HasMind
-            || !TryComp<MindComponent>(mc.Mind.Value, out var mind)
+            // || !TryComp<MindComponent>(mc.Mind.Value, out var mind)
             || !_player.TryGetSessionByEntity(uid, out var session))
             // || !_player.TryGetSessionById(mind.UserId, out var session))
         {
@@ -262,17 +258,13 @@ public sealed class StationPaySystem : EntitySystem
         while (_scheduledPayouts.Count > 0)
         {
             var first = _scheduledPayouts.Min!;
-            if (first.LastPayout + PayoutDelay > now)
+            var worked = (now - first.LastPayout) / _payoutDelay * _payoutDelay;
+            if (worked <= 0)
                 break;
 
-            PayoutFor(first.Uid, PayoutDelay);
+            PayoutFor(first.Uid, worked);
             _scheduledPayouts.Remove(first);
-
-            // it's possible that `now` is substantially past when this payout should have happened because
-            // the round can be paused or played at accelerated timescales. we do not assume we're paying on
-            // time, and thus we schedule the next payout relative to when this payout should have happened
-            // if we're way behind we'll catch up with several simultaneous payments here
-            var updated = new ScheduledPayout(first.Uid, first.LastPayout + PayoutDelay);
+            var updated = new ScheduledPayout(first.Uid, first.LastPayout + worked);
             _scheduledPayouts.Add(updated);
         }
 


### PR DESCRIPTION
* add support for players connecting/disconnecting during a shift
  * when someone detaches from their entity, their employed time stops being tracked (disconnect, atime, etc)
  * when someone attaches to their entity their employed time resumes from where it stopped
* normalize payout prototypes to unit value: payoutdelay now controls only how often payroll is performed, but will not affect the value they earn (which is defined by hour in the prototype, but is normalized to per second in the payroll code)
* add cvar for payout delay

this completes the station pay system assuming everything works as expected