### PR TITLE
Adds security IFF crate

### DIFF
--- a/Resources/Prototypes/_HL/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/_HL/Catalog/Cargo/cargo_security.yml
@@ -1,0 +1,10 @@
+- type: cargoProduct
+  id: SecurityIFF
+  # abstract: true # Frontier
+  icon:
+    sprite: Objects/Storage/boxes.rsi
+    state: box_security
+  product: CrateSecurityIFF
+  cost: 500
+  category: cargoproduct-category-name-security
+  group: market

--- a/Resources/Prototypes/_HL/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/_HL/Catalog/Fills/Crates/security.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: CrateSecurityIFF
+  parent: CrateSecgear
+  name: security IFF crate
+  description: Contains twelve security IFF light sets. Requires Security access to open.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingNeckIFFCyan
+        amount: 12


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a crate containing 12 cyan IFF sets, for use in the new station's armoury. The number is intentionally larger than the department can be, to support situations where the crew must be armed as well

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Would allow for easier coordination on-station, with consideration to the vast array of clothing and armour available from ship gameplay

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->