### PR TITLE
Mini Silo Update.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -23,6 +23,7 @@
       tags:
       - Sheet
       - Ingot
+      - RawMaterial
   - type: ActivatableUI
     key: enum.OreSiloUiKey.Key
   - type: ActivatableUIRequiresPower
@@ -60,3 +61,5 @@
   - type: WiresPanel
   - type: StaticPrice
     price: 300 # Frontier: 1500<300
+  - type: MaterialStorageMagnetPickup
+    range: 0.30


### PR DESCRIPTION
Silos now accept RawMaterials (Diamonds, Bananium, Cloth, Wood, etc.) and have a magnet component just like other machines with material storages.