### PR TITLE
Accessory slots

### DIFF
--- a/Content.Shared/Inventory/SlotFlags.cs
+++ b/Content.Shared/Inventory/SlotFlags.cs
@@ -27,6 +27,7 @@ public enum SlotFlags
     FEET = 1 << 14,
     SUITSTORAGE = 1 << 15,
     WALLET = 1 << 13, // Frontier: using an unused slot, redefine to a new bit if/when it's used (goodbye ushort)
+    ACCESSORY = 1 << 16,
     All = ~NONE,
 
     WITHOUT_POCKET = All & ~POCKET

--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -150,3 +150,18 @@
       dependsOn: jumpsuit
       displayName: Wallet
     # End Frontier: wallet slot
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 3,3
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 3,4
+      displayName: Accessory

--- a/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
@@ -105,3 +105,18 @@
       dependsOn: jumpsuit
       displayName: Wallet
     # End Frontier: wallet slot
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 2,1
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 0,3
+      displayName: Accessory

--- a/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
@@ -125,3 +125,18 @@
       dependsOn: jumpsuit
       displayName: Wallet
     # End Frontier: wallet slot
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 2,1
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 0,3
+      displayName: Accessory

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -131,3 +131,18 @@
       dependsOn: jumpsuit
       displayName: Wallet
     # End Frontier: wallet slot
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 2,1
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 0,3
+      displayName: Accessory

--- a/Resources/Prototypes/InventoryTemplates/mannequin_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/mannequin_inventory_template.yml
@@ -62,3 +62,18 @@
       uiWindowPos: 3,0
       strippingWindowPos: 0,2
       displayName: Back
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 2,1
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 0,3
+      displayName: Accessory

--- a/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/ipc_inventory_template.yml
+++ b/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/ipc_inventory_template.yml
@@ -141,3 +141,18 @@
       uiWindowPos: 3,0
       strippingWindowPos: 0,5
       displayName: Back
+    # Hardlight: accessory slots, originally three but the stripping window sucks
+    - name: accessory1
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 2,1
+      displayName: Accessory
+    - name: accessory2
+      slotTexture: neck
+      slotFlags: ACCESSORY
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 0,3
+      displayName: Accessory


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds two accessory slots to all inventory templates, for use with cosmetic items to not interfere with existing loadouts.

## Technical details
A new line was added to the SlotFlags.cs to whitelist the new inventory slots, which were then added to the inventory template files of each applicable species

## How to test
Load in, check inventory, there should be two additional 'neck' slots which accept accesories, though no items can currently go in them, check a Urist for the strip menu versions

## Media
(I wanted to attach screenshots of it but I changed branches back on our local)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Accessory slots to your inventory, expect items to fill those later
