### PR TITLE
liberation station restock box fix

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -23,7 +23,7 @@
   components:
   - type: VendingMachineRestock
     canRestock:
-    - AmmoVendInventory
+    - WeaponryWorksVendInventory
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Liberation station restock box now correctly restocks the liberation station.

## How to test
It goes in the square hole.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Lib station restocks work now
