### PR TITLE
directional fan in the RCD 

### DIFF
--- a/Resources/Locale/en-US/_Flooftier/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Flooftier/guidebook/guides.ftl
@@ -1,2 +1,2 @@
-#shipyard guidebook entry
+# shipyard guidebook entry
 guide-entry-shipyard-gondola = Gondola

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -340,6 +340,8 @@
     - HVCable
     - CableTerminal
     - Deconstruct
+    #Hardlight
+    - AtmosDeviceFanDirectional
   - type: LimitedCharges
     maxCharges: 30
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -54,3 +54,7 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  - type: RCDDeconstructable # HARDLIGHT
+    cost: 10 # HARDLIGHT
+    delay: 10 # HARDLIGHT
+  - type: rcd

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -57,4 +57,3 @@
   - type: RCDDeconstructable # HARDLIGHT
     cost: 10 # HARDLIGHT
     delay: 10 # HARDLIGHT
-  - type: rcd

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -273,3 +273,19 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+
+
+# HARD LIGHT
+
+# AIRLOCKs
+- type: rcd
+  id: AtmosDeviceFanDirectional
+  category: Airlocks
+  sprite: /Textures/Structures/Piping/Atmospherics/directionalfan.rsi/icon.png
+  mode: ConstructObject
+  prototype: AtmosDeviceFanDirectional
+  cost: 10
+  delay: 5
+  collisionMask: FullTileMask
+  rotation: User
+  fx: EffectRCDConstruct3

--- a/Resources/Prototypes/_HL/RCD/rcd.yml
+++ b/Resources/Prototypes/_HL/RCD/rcd.yml
@@ -1,0 +1,11 @@
+#- type: rcd
+#  id: AtmosDeviceFanDirectional
+#  category: Airlocks
+#  sprite: Structures/Piping/Atmospherics/directionalfan.rsi
+#  mode: ConstructObject
+#  prototype: AtmosDeviceFanDirectional
+#  cost: 10
+#  delay: 5
+#  collisionMask: FullTileMask
+#  rotation: Camera
+#  fx: EffectRCDConstruct3


### PR DESCRIPTION

## Why / Balance

With how the cultural and how this server is in nature.  not being able to move or create a directional fan stops how you want to customize or build your ship when in-game. Thus I added the fans to the RCD and able to deconstruct them. people shouldn't be bugging or asking admins for it especially when the server grows more and more

However, I feel like if people are going to abuse this, it should require Admin action at that point 


## Media
<img width="382" height="347" alt="image" src="https://github.com/user-attachments/assets/0bb3055f-6a69-4ac5-a190-25eb02631ecb" />

<img width="263" height="189" alt="image" src="https://github.com/user-attachments/assets/544a326b-32db-403c-8af9-7dc3cb79091e" />

**Changelog**

:cl:
- add: Directional fan to RCDs
-->
