### PR TITLE
SESWC restore

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
@@ -552,11 +552,11 @@
     state: white
 
 - type: entity
-  name: toy rocket launcher
+  name: Emotional support RPG
   parent: [BaseClearContraband, NFWeaponLauncherRocket]
   id: WeaponLauncherRocketToy
   suffix: Toy
-  description: A plush toy, this launches foam "grenades". There are stitches on the side that spell out "SAM".
+  description: A plush toy, this launches foam "grenades". Design by SESWC  # Hardlight
   components:
   - type: Sprite
     sprite: _NF/Objects/Fun/emotional_support_rpg.rsi

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -217,9 +217,9 @@
 
 - type: entity
   id: WeaponRifleSVS
-  name: SVS-42 (7.62x54mmR)
+  name: SVT-42 (7.62x54mmR)
   parent: [ BaseWeaponRifle, BaseGunMelee, BaseC1Contraband ]
-  description: "Originally designed by Samonov, this old surplus rifle looks like it's seen a few wars. Uses low capacity 10 rounder 7.62x54mmR magazines. Equipped with bayonet."
+  description: "Originally designed by SESWC, this old surplus rifle looks like it's seen a few wars. Uses low capacity 10 rounder 7.62x54mmR magazines. Equipped with bayonet."  #Hardlight
   components:
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Rifles/svs42.rsi
@@ -235,10 +235,11 @@
     - Back
     - suitStorage
   - type: Gun
-    fireRate: 1.9
+    fireRate: 5  # highly underpower so buff  Hardlight
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/brassknuckles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/brassknuckles.yml
@@ -2,7 +2,7 @@
   name: brass knuckles
   parent: ClothingHandsBase
   id: WeaponBrassKnuckles
-  description: When you need to punch just a little harder.
+  description: When you need to punch just a little harder. Design by SESWC  #Hardlight
   components:
   - type: Sprite
     sprite: _NF/Objects/Weapons/Melee/brassknuckles.rsi


### PR DESCRIPTION

## About the PR
The one thing I have asked for from Frontier Devs, or in fact any server devs, is just to allow me to keep my SESWC in the description, and well, l it seems to all be changed 


## Why / Balance
With the amount of things I try to do for servers and the amount of time I take to try and make these PR., all I wish is to allow my work to be tracked with the SESWC staple in the description 


## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
 No change log 
