### PR TITLE
V1 quick and dirty Security Fuc takin Vending machine 

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_HL/Entities/Structures/Machines/vending_machines.yml
@@ -1,0 +1,47 @@
+- type: entity
+  parent: [BaseStructureDisableAnchoring, StorePresetSecurityUplink, VendingMachine]
+  id: VendingMachineSecurityVend1
+  name: SecurityVend
+  description: Desgin by SESWC to help every officers day
+  components:
+  - type: VendingMachine
+    cashSlot: Null
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+    ejectState: eject-unshaded
+    denyState: deny-unshaded
+#   screenState: screen
+  - type: Sprite
+    sprite: _NF/Structures/Machines/VendingMachines/mercvend.rsi
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+      shader: unshaded
+#   - state: "screen"
+#     map: ["enum.VendingMachineVisualLayers.Screen"]
+#     shader: unshaded
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: PointLight
+    radius: 1.5
+    energy: 1.3
+    color: "#0492c2"
+  - type: UserInterface
+    interfaces:
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+  - type: ActivatableUI
+    key: enum.StoreUiKey.Key
+  - type: Tag
+    tags:
+    - SecurityUplink
+    - SecurityVend
+#  - type: Store
+#    balance:
+#      MercCoin: 0 # Waits for the player to put in money
+  - type: AccessReader
+    access: [["Security"]]
+  - type: ActivatableUIRequiresAccess

--- a/Resources/Prototypes/_HL/tags.yml
+++ b/Resources/Prototypes/_HL/tags.yml
@@ -275,3 +275,9 @@
 
 - type: Tag
   id: Fungal
+
+
+# Vending machines
+
+- type: Tag
+  id: SecurityVend


### PR DESCRIPTION
## About the PR
No one has uplinks for security, so why collect FUC when you can't use it 

This is the First version of the vending machine, so security players can be rewarded for their HARD work of ruining the syndicate SCUM

## Technical details
I have mapped it in Sec, but also took 1 of the lockers away 

## How to test

go on core look at it in the sec room 
spawn in the vending machines and used fuc


## Media

<img width="819" height="867" alt="image" src="https://github.com/user-attachments/assets/ab229981-47be-45aa-9a67-9a74de49fb6c" />


## Breaking changes
change Core 

**Changelog**

:cl:
- add: Security Vending machine  
- tweak: Core map now has a Sec vending

-->
