### PR TITLE
Update ipc.yml to allow hair

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -47,10 +47,10 @@
   id: MobIPCMarkingLimits
   points:
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
-      points: 0
+      points: 1
       required: false
     Head:
       points: 1


### PR DESCRIPTION
IPCs being allowed to have 'synthhair' adds a nice extra layer of customization to a delightfully customizable species.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the markings for IPCs to allow hair to be added.

## Why / Balance
It is a nice level of customization, and easily explained in roleplay.

## Technical details
Just changed a 0 to a 1.

## How to test
Load an IPC character with hair, and ensure everything appears properly in game. If it does not, further code changes can be looked into.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
- [ x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ x] I confirm that AI tools were not used in generating the material in this PR.


**Changelog**
:cl:
- add: IPCs can now choose hair options in the character creation menu.
-->
