### PR TITLE
Mining module added back to the exo 

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -30,6 +30,7 @@
   - BorgModuleDiagnosis
   - BorgModuleNFService
   - BorgModuleRCDShipyard
+  - BorgModuleMining
 
 - type: latheRecipePack
   id: BorgModulesDynamic

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -13,7 +13,7 @@
   - MiningDrill
   - WeaponGrapplingGun # Frontier
   - MineralScannerEmpty
-  - BorgModuleMining
+  #- BorgModuleMining # HL
   - BorgModuleGrapplingGun
   - OreProcessorIndustrialMachineCircuitboard
   - ClothingMaskWeldingGas


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
wasn't obtainable, this pr removes it from research so everyone can print it from the start
## Why / Balance
Why no mining borg?

## How to test
Look in the exofab

**Changelog**

:cl:
- add: Added the Mining module to be round start in the ExoFab
-->
