### PR TITLE
Balancing halberds in order of fenn's requirement

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
@@ -31,7 +31,8 @@
       params:
         volume: 3
   - type: Reflect # so it doenst inherit the reflect from the Dsword
-    reflectProb: .00
+    reflectProb: .50
+    spread: 75
   - type: Item
     size: Huge
     sprite: _HL/Objects/Weapons/Melee/e_halberd-inhands.rsi
@@ -53,8 +54,8 @@
       right:
       - state: inhand-right-blade
         shader: unshaded
-  - type: IgniteOnMeleeHit
-    fireStacks: 5
+  # - type: IgniteOnMeleeHit
+  #   fireStacks: 0
   - type: NFWeaponDetails
     manufacturer: weapon-details-manufacturer-SESWC-consortium
 
@@ -73,8 +74,8 @@
         visible: false
         shader: unshaded
         map: [ "blade" ]
-  - type: IgniteOnMeleeHit
-    fireStacks: 0
+  # - type: IgniteOnMeleeHit
+  #   fireStacks: 0
   - type: Reflect # placeholder until I give them a speical thing like Syndicates have and Cartels have
     reflectProb: .50
     spread: 75
@@ -103,8 +104,8 @@
       right:
       - state: inhand-right-blade-P
         shader: unshaded
-  - type: IgniteOnMeleeHit
-    fireStacks: 0
+  # - type: IgniteOnMeleeHit
+  #   fireStacks: 0
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 0.75
@@ -121,11 +122,12 @@
         variation: 0.250
     activatedDamage:
         types:
-            Caustic: 20
+            Heat: 10
+            Caustic: 5
             Structural: 50
   - type: MeleeChemicalInjector
     solution: Ruin
-    transferAmount: 1.7
+    transferAmount: 0.5
   - type: SolutionContainerManager
     solutions:
       Ruin:

--- a/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
@@ -2,7 +2,7 @@
   name: energy halberd
   parent: EnergySwordDouble
   id: WeaponEnergyHalberd
-  description: A polarm with an energy-based axe head and spike. Produced by SESWC.
+  description: A polearm with an energy-based axe head and spike. Produced by SESWC.
   components:
   - type: ItemToggleSize
     activatedSize: Huge
@@ -63,7 +63,7 @@
   name: antique energy halberd
   parent: WeaponEnergyHalberd
   id: WeaponEnergyHalberdAntique
-  description: A two-handed polarm, also know as a halberd. Ideal for a warden looking to protect their armoury. Designed and produced by SESWC.
+  description: A two-handed polearm, also know as a halberd. Ideal for a warden looking to protect their armoury. Designed and produced by SESWC.
   components:
   - type: Sprite
     sprite: _HL/Objects/Weapons/Melee/e_halberd.rsi
@@ -84,7 +84,7 @@
   name: cartel energy halberd
   parent: WeaponEnergyHalberd
   id: WeaponEnergyHalberdC
-  description: A two-handed polarm, also know as a halberd. This variant uses a purple focusing crystal, and the branding has been painted over.
+  description: A two-handed polearm, also know as a halberd. This variant uses a purple focusing crystal, and the branding has been painted over.
   components:
   - type: Sprite
     sprite: _HL/Objects/Weapons/Melee/e_halberd.rsi

--- a/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
@@ -123,7 +123,7 @@
     activatedDamage:
         types:
             Heat: 10
-            Caustic: 5
+            Caustic: 7
             Structural: 50
   - type: MeleeChemicalInjector
     solution: Ruin

--- a/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Weapons/Melee/energy.yml
@@ -63,7 +63,7 @@
   name: antique energy halberd
   parent: WeaponEnergyHalberd
   id: WeaponEnergyHalberdAntique
-  description: A two-handed polearm, also know as a halberd. Ideal for a warden looking to protect their armoury. Designed and produced by SESWC.
+  description: A two-handed polearm, also known as a halberd. Ideal for a warden looking to protect their armoury. Designed and produced by SESWC.
   components:
   - type: Sprite
     sprite: _HL/Objects/Weapons/Melee/e_halberd.rsi
@@ -84,7 +84,7 @@
   name: cartel energy halberd
   parent: WeaponEnergyHalberd
   id: WeaponEnergyHalberdC
-  description: A two-handed polearm, also know as a halberd. This variant uses a purple focusing crystal, and the branding has been painted over.
+  description: A two-handed polearm, also known as a halberd. This variant uses a purple focusing crystal, and the branding has been painted over.
   components:
   - type: Sprite
     sprite: _HL/Objects/Weapons/Melee/e_halberd.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes syndicate halberd and cartel halberd in order to bring them in line to the standard access ones.

## Why / Balance
Ensures 22 damage standard across halberds. changing syndicate to only deal 22 heat and 50 structural removing fire stacks, Setting cartel halberd ruin inject to 0.5 units and set damage to 10 heat and 7 caustic.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
