### PR TITLE
Vortex slight rebalance 

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -24,7 +24,7 @@
   name: Vortex-12
   parent: [ WeaponShotgunBulldog, BaseGunMeleeBlunt ]
   id: WeaponShotgunVortex
-  description: Designed by SESWC. An automatic magazine-fed shotgun for close-quarters combat #with an auto magazine ejector
+  description: Designed by SESWC. An semi-automatic magazine-fed shotgun for close-quarters combat #with an auto magazine ejector
   components:
   - type: NFWeaponDetails
     manufacturer: weapon-details-manufacturer-SESWC-consortium
@@ -50,13 +50,17 @@
   - type: AmmoCounter
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun  # Have to do this to reduce the firerate
-    fireRate: 1.5
-    selectedMode: SemiAuto #bulldog is full auto
+    fireRate: 1
+    selectedMode: SemiAuto
     availableModes:
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
+  - type: Contraband # Try to do parent but bulldog override it thus This
+    severity: Class1
+    # Pretty much everyone.
+    allowedDepartments: [ Civilian, Security, Command, Frontier, CentralCommand ]  #IF we had a merc department we can expand on it
   #- type: ChamberMagazineAmmoProvider
   #  autoEject: true

--- a/Resources/Prototypes/_HL/Loadouts/loadouts.yml
+++ b/Resources/Prototypes/_HL/Loadouts/loadouts.yml
@@ -143,7 +143,7 @@
 # Merc guns
 
 - type: loadout
-  id: MercenaryVortexLoadout
+  id: MercenaryShotgunVortexLoadout
   price: 50000
   storage:
     back:

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -174,7 +174,7 @@
   - MercenaryLaserCarbineLoadout
   - MercenaryLaserCannonLoadout
   - MercenaryDisablerSMGLoadout
-  - MercenaryVortexLoadout # hard light
+  - MercenaryShotgunVortexLoadout # hard light
   fallbacks:
   - MercenaryWt550Loadout
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changes the Class 3 to Class 1 as it is a loadout item and can be bought from loadouts 
## Why / Balance
Class 3 means no one is posted to have it, so the sec is a post to arrest/take on sight 
also made the gun fire slower 
and change the ID for the loadout 

## Media
NA

**Changelog**

:cl:
- tweak:  Vortex is reclassified as C1

