### PR TITLE
Add floof's underwear system

### DIFF
--- a/Content.Server/_Floof/ModifyUndies/ModifyUndiesComponent.cs
+++ b/Content.Server/_Floof/ModifyUndies/ModifyUndiesComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Humanoid;
+
+
+namespace Content.Server.FloofStation.ModifyUndies;
+
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent]
+public sealed partial class ModifyUndiesComponent : Component
+{
+    /// <summary>
+    ///     The bodypart target enums for the undies.
+    /// </summary>
+    public List<HumanoidVisualLayers> BodyPartTargets =
+    [
+        HumanoidVisualLayers.UndergarmentTop,
+        HumanoidVisualLayers.UndergarmentBottom
+    ];
+}
+
+

--- a/Content.Server/_Floof/ModifyUndies/ModifyUndiesSystem.cs
+++ b/Content.Server/_Floof/ModifyUndies/ModifyUndiesSystem.cs
@@ -1,0 +1,250 @@
+using System.Linq;
+using Content.Server.Humanoid;
+using Content.Shared.DoAfter;
+using Content.Shared.Floofstation;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Server.Audio;
+using Robust.Shared.Audio;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+
+namespace Content.Server.FloofStation.ModifyUndies;
+
+
+/// <summary>
+/// This is a component that lets you show/hide specific underwear slots.
+///
+/// </summary>
+public sealed class ModifyUndiesSystem : EntitySystem
+{
+    [Dependency] private readonly MarkingManager _markingManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly EntityManager _entMan = default!;
+
+    public static readonly VerbCategory UndiesCat =
+        new("verb-categories-undies", "/Textures/Interface/VerbIcons/undies.png");
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ModifyUndiesComponent, GetVerbsEvent<Verb>>(AddModifyUndiesVerb);
+        SubscribeLocalEvent<ModifyUndiesComponent, ModifyUndiesDoAfterEvent>(ToggleUndies);
+    }
+
+    private void AddModifyUndiesVerb(EntityUid uid, ModifyUndiesComponent component, GetVerbsEvent<Verb> args)
+    {
+        if (args.Hands == null || !args.CanAccess ||!args.CanInteract)
+            return;
+        if (!TryComp<HumanoidAppearanceComponent>(args.Target, out var humApp))
+            return;
+        if (args.User != args.Target && _entMan.System<InventorySystem>().TryGetSlotEntity(args.Target, "jumpsuit", out _))
+            return; // mainly so people cant just spy on others undies *too* easily
+        var isMine = args.User == args.Target;
+        // okay go through their markings, and find all the undershirts and underwear markings
+        // <marking_ID>, list:(localized name, bodypart enum, isvisible)
+        foreach (var marking in humApp.MarkingSet.Markings.Values.SelectMany(markingLust => markingLust))
+        {
+            if (!_markingManager.TryGetMarking(marking, out var mProt))
+                continue;
+            // check if the Bodypart is in the component's BodyPartTargets
+            if (!component.BodyPartTargets.Contains(mProt.BodyPart))
+                continue;
+            var localizedName = Loc.GetString($"marking-{mProt.ID}");
+            var partSlot = mProt.BodyPart;
+            var isVisible = !humApp.HiddenLayers.Contains(partSlot);
+            if (mProt.Sprites.Count < 1)
+                continue; // no sprites means its not visible means its kinda already off and you cant put it on
+            var undieOrBra = partSlot switch
+            {
+                HumanoidVisualLayers.UndergarmentTop => new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/bra.png")),
+                HumanoidVisualLayers.UndergarmentBottom => new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/underpants.png")),
+                _ => new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/undies.png"))
+            };
+            // add the verb
+            Verb verb = new()
+            {
+                Text = Loc.GetString(
+                    "modify-undies-verb-text",
+                    ("undies", localizedName),
+                    ("isVisible", isVisible),
+                    ("isMine", isMine),
+                    ("target", Identity.Entity(args.Target, EntityManager))
+                    ),
+                Icon = undieOrBra,
+                Category = UndiesCat,
+                Act = () =>
+                {
+                    var ev = new ModifyUndiesDoAfterEvent(
+                        marking,
+                        localizedName,
+                        isVisible
+                        );
+                    var doAfterArgs = new DoAfterArgs(
+                        EntityManager,
+                        args.User,
+                        TimeSpan.FromSeconds(2),
+                        ev,
+                        args.Target,
+                        args.Target,
+                        used: args.User
+                    )
+                    {
+                        Hidden = false,
+                        MovementThreshold = 0,
+                        RequireCanInteract = true,
+                        BlockDuplicate = true
+                    };
+                    string gString;
+                    if (args.User == args.Target)
+                    {
+                        gString = isVisible
+                            ? "undies-removed-self-start"
+                            : "undies-equipped-self-start";
+                        _popupSystem.PopupCoordinates(
+                            Loc.GetString(
+                                gString,
+                                ("undie", localizedName)
+                                ),
+                            Transform(args.Target).Coordinates,
+                            Filter.Entities(args.Target),
+                            true,
+                            PopupType.Medium);
+                    }
+                    // someone doing this to someone else
+                    else
+                    {
+                        // to the user
+                        gString = isVisible
+                            ? "undies-removed-user-start"
+                            : "undies-equipped-user-start";
+                        _popupSystem.PopupCoordinates(
+                            Loc.GetString(
+                                gString,
+                                ("undie", localizedName)
+                                ),
+                            Transform(args.Target).Coordinates,
+                            Filter.Entities(args.User),
+                            true,
+                            PopupType.Medium);
+                        // to the target
+                        gString = isVisible
+                            ? "undies-removed-target-start"
+                            : "undies-equipped-target-start";
+                        _popupSystem.PopupCoordinates(
+                            Loc.GetString(
+                                gString,
+                                ("undie", localizedName),
+                                ("user", Identity.Entity(args.User, EntityManager))
+                                ),
+                            Transform(args.Target).Coordinates,
+                            Filter.Entities(args.Target),
+                            true,
+                            PopupType.MediumCaution);
+                    }
+                    // and then play a sound!
+                    var rufthleAudio = new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg");
+                    _audio.PlayEntity(
+                        rufthleAudio,
+                        Filter.Entities(args.User, args.Target),
+                        args.Target,
+                        false,
+                        AudioParams.Default.WithVariation(0.5f).WithVolume(0.5f));
+                    _doAfterSystem.TryStartDoAfter(doAfterArgs);
+                    // ToggleUndies(uid, mProt, isVisible, localizedName, args.User, args.Target, humApp);
+                },
+                Disabled = false,
+                Message = null
+            };
+            args.Verbs.Add(verb);
+        }
+    }
+    private void ToggleUndies(
+        EntityUid uid,
+        ModifyUndiesComponent component,
+        ModifyUndiesDoAfterEvent args
+        )
+    {
+        if (!_markingManager.TryGetMarking(args.Marking, out var mProt))
+            return;
+        if (!TryComp<HumanoidAppearanceComponent>(args.Target, out var humApp))
+            return;
+
+        var partSlot = mProt.BodyPart;
+
+        _humanoid.SetLayerVisibility(
+            uid,
+            partSlot,
+            !args.IsVisible
+        );
+        // then make a text bubble!
+        // one for the doer, one for the target
+        // and one if the doer is the target
+        // Effect targets for different players
+        // Popups
+        string gString;
+        if (args.User == args.Target.Value)
+        {
+            gString = args.IsVisible
+                ? "undies-removed-self"
+                : "undies-equipped-self";
+            _popupSystem.PopupCoordinates(
+                Loc.GetString(
+                    gString,
+                    ("undie", args.MarkingPrototypeName)
+                    ),
+                Transform(args.Target.Value).Coordinates,
+                Filter.Entities(args.Target.Value),
+                true,
+                PopupType.Medium);
+        }
+        // someone doing this to someone else
+        else
+        {
+            // to the user
+            gString = args.IsVisible
+                ? "undies-removed-user"
+                : "undies-equipped-user";
+            _popupSystem.PopupCoordinates(
+                Loc.GetString(
+                    gString,
+                    ("undie", args.MarkingPrototypeName)
+                    ),
+                Transform(args.Target.Value).Coordinates,
+                Filter.Entities(args.User),
+                true,
+                PopupType.Medium);
+            // to the target
+            gString = args.IsVisible
+                ? "undies-removed-target"
+                : "undies-equipped-target";
+            _popupSystem.PopupCoordinates(
+                Loc.GetString(
+                    gString,
+                    ("undie", args.MarkingPrototypeName),
+                    ("user", Identity.Entity(args.User, EntityManager))
+                    ),
+                Transform(args.Target.Value).Coordinates,
+                Filter.Entities(args.Target.Value),
+                true,
+                PopupType.Medium);
+        }
+        // and then play a sound!
+        var rufthleAudio = new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg");
+        _audio.PlayEntity(
+            rufthleAudio,
+            Filter.Entities(args.User, args.Target.Value),
+            args.Target.Value,
+            false,
+            AudioParams.Default.WithVariation(0.5f).WithVolume(0.5f));
+    }
+}

--- a/Content.Shared/Floofstation/ModifyUndiesDoAfterEvent.cs
+++ b/Content.Shared/Floofstation/ModifyUndiesDoAfterEvent.cs
@@ -1,0 +1,51 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
+using Robust.Shared.Serialization;
+
+
+namespace Content.Shared.Floofstation;
+
+
+[Serializable, NetSerializable]
+public sealed partial class ModifyUndiesDoAfterEvent : DoAfterEvent
+{
+    /// <summary>
+    ///     The marking prototype that is being modified.
+    /// </summary>
+    [DataField("markingPrototype", required: true)]
+    public Marking Marking;
+
+    /// <summary>
+    ///     Localized string for the marking prototype.
+    /// </summary>
+    [DataField("markingPrototypeName", required: true)]
+    public string MarkingPrototypeName;
+
+    /// <summary>
+    ///     Whether or not the marking is visible at the moment.
+    /// </summary>
+    [DataField("visible", required: true)]
+    public bool IsVisible;
+
+    private ModifyUndiesDoAfterEvent()
+    {
+        Marking = default!;
+        MarkingPrototypeName = string.Empty;
+        IsVisible = false;
+    }
+
+    public ModifyUndiesDoAfterEvent(
+        Marking marking,
+        string markingPrototypeName,
+        bool isVisible
+        )
+    {
+        Marking = marking;
+        MarkingPrototypeName = markingPrototypeName;
+        IsVisible = isVisible;
+    }
+
+    public override DoAfterEvent Clone() => this;
+}
+

--- a/Resources/Locale/en-US/Floof/markings/modify_undies.ftl
+++ b/Resources/Locale/en-US/Floof/markings/modify_undies.ftl
@@ -1,0 +1,27 @@
+verb-categories-undies = Modify Undies
+
+modify-undies-verb-text = {$isVisible ->
+*[false] Put on
+[true] Take off
+} {$isMine ->
+*[false] {$target}'s
+[true] your
+} {$undies}
+
+undies-removed-self-start = You start taking off your {$undie}.
+undies-equipped-self-start = You start putting on your {$undie}.
+
+undies-removed-user-start = You start taking their {$undie} off.
+undies-equipped-user-start = You start putting their {$undie} on them.
+
+undies-removed-target-start = {PROPER($user)} starts taking your {$undie} off.
+undies-equipped-target-start = {PROPER($user)} starts putting your {$undie} on you.
+
+undies-removed-self = You take off your {$undie}.
+undies-equipped-self = You put on your {$undie}.
+
+undies-removed-user = You take their {$undie} off.
+undies-equipped-user = You put their {$undie} on them.
+
+undies-removed-target = {PROPER($user)} takes your {$undie} off.
+undies-equipped-target = {PROPER($user)} puts your {$undie} on you.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Adds floof station's underwear system. Changes some of the code to support upstream's undergarments.

## Media

https://github.com/user-attachments/assets/ca0ca47e-454c-46be-b54a-bda295b0d8bb



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- tweak: You can now take off people's undergarments with a verb, ported from floofstation.