### PR TITLE
Tweaked the Security Uplink cash purchase options

### DIFF
--- a/Resources/Locale/en-US/_HL/store/SecurityVending.ftl
+++ b/Resources/Locale/en-US/_HL/store/SecurityVending.ftl
@@ -1,6 +1,6 @@
 # Bug fixs these items are from Mono or NF #
-uplink-security-cash1000-name = 1,000 Spesos
-uplink-security-cash1000-desc = Cold, hard cash.
+uplink-security-cash10000-name = 10,000 Spesos
+uplink-security-cash10000-desc = Cold, hard cash.
 uplink-security-cash45000-name = 100,000 Spesos
 uplink-security-cash45000-desc = Money for contraband turn ins.
 

--- a/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
@@ -65,21 +65,21 @@
       tags:
       - SecurityUplink
 
-- type: listing
-  id: UplinkSecurityCash45000 # HL starts : Changes the cash from 75k to using 45k
-  name: uplink-security-cash45000-name
-  description: uplink-security-cash45000-desc
-  productEntity: SpaceCashExpeditionT5 # HL ends
-  icon: { sprite: _NF/Objects/Economy/cash.rsi, state: cash_100000 }
-  cost:
-    FrontierUplinkCoin: 10
-  categories:
-    - UplinkSecurityUtility
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - SecurityUplink
+#- type: listing # HL Change. Removed duplicate cash option.
+#  id: UplinkSecurityCash45000 # HL starts : Changes the cash from 75k to using 45k
+#  name: uplink-security-cash45000-name
+#  description: uplink-security-cash45000-desc
+#  productEntity: SpaceCashExpeditionT5 # HL ends
+#  icon: { sprite: _NF/Objects/Economy/cash.rsi, state: cash_100000 }
+#  cost:
+#    FrontierUplinkCoin: 10
+#  categories:
+#    - UplinkSecurityUtility
+#  conditions:
+#    - !type:StoreWhitelistCondition
+#      whitelist:
+#        tags:
+#          - SecurityUplink
 
 - type: listing
   id: UplinkSecurityMagazineSubsonic

--- a/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
@@ -1071,11 +1071,11 @@
           - SecurityUplink
 
 - type: listing
-  id: UplinkSecurityCash1000
-  name:  uplink-security-cash1000-name
-  description: uplink-security-cash1000-desc
-  productEntity: SpaceCash1000
-  icon: { sprite: Objects/Economy/cash.rsi, state: cash_1000 }
+  id: UplinkSecurityCash10000
+  name:  uplink-security-cash10000-name
+  description: uplink-security-cash10000-desc
+  productEntity: SpaceCash10000
+  icon: { sprite: Objects/Economy/cash.rsi, state: cash_10000 }
   cost:
     FrontierUplinkCoin: 1
   categories:
@@ -1091,7 +1091,7 @@
   name:  uplink-security-cash45000-name
   description: uplink-security-cash1000-desc
   productEntity: SpaceCash100000
-  icon: { sprite: Objects/Economy/cash.rsi, state: cash_25000 }
+  icon: { sprite: Objects/Economy/cash.rsi, state: cash_100000 }
   cost:
     FrontierUplinkCoin: 10
   categories:


### PR DESCRIPTION

## About the PR
I tweaked the 1000 spesos for 1 FUC option so that it now grants 10000 spesos. That way the value is consistent with the 100,000 speso option.

The sprite for the 100,000 speso purchase showed a 25k speso bill, so I changed it to display the proper sprite.

There were two options that paid out 100k spesos for 10 FUC, so I removed one of the duplicates.

## Why / Balance
This should make contraband turn-ins more consistent, as 1 FUC is always worth 10k now.

## Technical details
A handful of YAML changes and a slight tweak to the localization files.

## How to test
Spawn in a SecurityVend/Sec uplink and check the utilities section.

## Media
N/A

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made the cash payouts for Frontier Uplink Coins more consistent
- fix: Removed a duplicate cash payout option from the SecurityVend
