### PR TITLE
Tweaked the footstep sounds for cloth and transparent cloth footwraps.

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Clothing/SocksAndSuch.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/SocksAndSuch.yml
@@ -464,6 +464,9 @@
     sprite: _HL/Clothing/Socks/clothwraptransparent.rsi
   - type: Clothing
     sprite: _HL/Clothing/Socks/clothwraptransparent.rsi
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: BarestepHard
 
 #Evening Wear
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Shoes/misc.yml
@@ -48,3 +48,6 @@
   - type: Construction
     graph: CraftShoesClothwrap
     node: CraftShoesClothwrap
+  - type: FootstepModifier # HL Change
+    footstepSoundCollection:
+      collection: BarestepHard


### PR DESCRIPTION

## About the PR
Footwraps now use the barefoot sound collection when walking.

## Why / Balance
It doesn't really make sense for them to make shoe/boot walking sounds (especially the transparent ones, which are supposed to simulate being barefoot without the downsides.)

## Technical details
Just a few lines of YML code.

## How to test
Wear some cloth wraps and walk around!

## Media
N/A

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Cloth and transparent footwraps now sound like you're barefoot!