### PR TITLE
Making the AME sane.

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -179,7 +179,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
-        return 2000000f * fuel * fuel / cores;
+        return 20000f * fuel * fuel / cores; // Hardlight (1 core 2 fuel = 80kw)
     }
 
     public int GetTotalStability()


### PR DESCRIPTION

## About the PR
Guts the AME's power production capability by a factor of 100.

## Why / Balance
The AME, as it is, is HILARIOUSLY broken in terms of power output. A single AME core, set to 2 injection, can produce 8MW. This is, quite frankly, complete insanity. There is nothing in the game that needs this much power apart from selling it, which feels a little silly for something as simple as the AME. So, I'm here to put an end to the AME's frankly ridiculous power output, and bring it down to something more reasonable. The new formula will instead produce 80kw per core at optimum injection rate. This keeps it viable for stations as well as shuttles without feeling like complete overkill (as well as requiring engineering to set up proper engines if they want to sell power).

## Technical details
I removed 2 zeros from a formula.

## How to test
Build an AME.
Insert fuel
Toggle injection
Look at the numbers.

## Media
Nuh

## Breaking changes
This will probably require several HL unique stations to have their AME cores expanded to meet demand (as the wizden stations do have appropriately sized AME's for this kind of output). I haven't been able to play many of them but I know that Hardlight Core will probably need an increase to a 4 or even 5 core AME.

**Changelog**

:cl: R3v3l4t1ion
- tweak: AME's now produce a sensible amount of power instead of literal MW's. You will need to use more than 2 injection.
