### PR TITLE
Shadekin Damage Correction

### DIFF
--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -8,12 +8,10 @@
 - type: damageModifierSet
   id: Shadekin
   coefficients:
-    Blunt: 1
-    Slash: 1
-    Piercing: 1
-    Heat: 1
-    Cold: 1
-    Shock: 1
-    Radiation: 1
-    Poison: 1
-
+    Asphyxiation: 0
+    Cold: 0.75
+    Heat: 1.2
+    Cellular: 0.15
+    Bloodloss: 1.25
+    Shock: 0.75
+    Radiation: 1.3


### PR DESCRIPTION
## About the PR
Changed shadekin damage coefficients to match intended values shown in guidebook.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So, ignore me if I'm dead wrong but this is the only place I could find a damage modifier with an id of Shadekin. Which means shadekin have just been taking base damage and double bloodloss damage since they've been added, which if its intended fine, but if not then this fixes that.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn Urist McShadows
Hit with various weapons/effects
view damage values and see the difference between damage applied

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: changed shadekin damagemodifierset coefficients