### PR TITLE
Fix robotics console and give regular borgs a hand

### DIFF
--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
@@ -16,7 +16,7 @@
 
         <!-- Selected borg info -->
         <Label Name="SelectCyborg" Text="{Loc 'robotics-console-select-cyborg'}" HorizontalAlignment="Center"/>
-        <BoxContainer Name="BorgContainer" Orientation="Vertical" MaxHeight="200" Visible="False">
+        <BoxContainer Name="BorgContainer" Orientation="Vertical" MaxHeight="300" Visible="False">
             <BoxContainer Margin="5 5 5 5" Orientation="Horizontal">
                 <PanelContainer VerticalExpand="True">
                     <BoxContainer HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
+++ b/Content.Client/Robotics/UI/RoboticsConsoleWindow.xaml
@@ -16,7 +16,7 @@
 
         <!-- Selected borg info -->
         <Label Name="SelectCyborg" Text="{Loc 'robotics-console-select-cyborg'}" HorizontalAlignment="Center"/>
-        <BoxContainer Name="BorgContainer" Orientation="Vertical" MaxHeight="300" Visible="False">
+        <BoxContainer Name="BorgContainer" Orientation="Vertical" MaxHeight="350" Visible="False">
             <BoxContainer Margin="5 5 5 5" Orientation="Horizontal">
                 <PanelContainer VerticalExpand="True">
                     <BoxContainer HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -454,7 +454,7 @@
   abstract: true
   components:
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: Inventory
     templateId: borgquad #Hardlight - Changes Quadborgs over to use our armor slots
   - type: RandomMetadata

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -6,6 +6,8 @@
   save: false
   abstract: true
   components:
+  - type: Body
+    prototype: Borg
   - type: Reactive
     groups:
       Acidic: [Touch]
@@ -153,7 +155,6 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-  - type: Body
   - type: StatusEffects
     allowed:
     - Flashed

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -181,7 +181,7 @@
     factions:
     - Xenoborg
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: Hands
     showInHands: false
     disableExplosionRecursion: true

--- a/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -3,7 +3,7 @@
   parent: BaseBorgChassisNT
   components:
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: QuadborgSpriteOffset # HardLight
     defaultOffset: 0,0.2
     bigOffset: 0,0.3

--- a/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -10,7 +10,7 @@
     smallOffset: 0,0.1
     tinyOffset: 0,0.075
   - type: Inventory
-    speciesId: quadborg
+    speciesId: Borg
     templateId: borgquad # Hardlight: Changes Quadborgs over to use our armor slots
   - type: Fixtures # HardLight
     fixtures:

--- a/Resources/Prototypes/_HL/Body/Prototypes/Borg.yml
+++ b/Resources/Prototypes/_HL/Body/Prototypes/Borg.yml
@@ -1,6 +1,6 @@
 - type: body
-  id: Quadborg
-  name: "Quadborg"
+  id: Borg
+  name: "Borg"
   root: torso
   slots:
     torso:

--- a/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/RaptBorg.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/RaptBorg.yml
@@ -3,7 +3,7 @@
   parent: BaseBorgChassisNT
   components:
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: Sprite
     sprite: _HL/Mobs/Silicon/RaptBorg.rsi
     scale: 0.5, 0.5
@@ -88,7 +88,7 @@
   parent: BaseBorgChassisNT
   components:
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: Sprite
     sprite: _HL/Mobs/Silicon/RaptBorg.rsi
     scale: 0.5, 0.5
@@ -173,7 +173,7 @@
   parent: BaseBorgChassisNT
   components:
   - type: Body
-    prototype: Quadborg
+    prototype: Borg
   - type: Sprite
     sprite: _HL/Mobs/Silicon/RaptBorg.rsi
     scale: 0.5, 0.5


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes the robotics console regarding quadborgs and them being unable to be disabled or destroyed when rogue.
Gives regular borgs a hand, bringing them in parity with quads

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Robotics console was bugged and was unable to destroy and disable quads due to sprite size. 
Regular cyborgs granted a hand so they may interact with their ID slot and Armor slot, alongside owning shuttles.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added a hand to regular cyborgs.
- fix: Fixed robotics console not being able to affect quads.
