### PR TITLE
Make the AME sane, but not TOO sane.

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -179,7 +179,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
-        return 2000000f * fuel * fuel / cores;
+        return 90000f * fuel * fuel / cores; // Hardlight: 2000000f -> 90000f (8MW -> 180kW)
     }
 
     public int GetTotalStability()


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
A version of https://github.com/HardLightSector/HardLight/pull/1206 that is less nerfing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
8MW per core *IS* too much, but 80kW per core is also too little.
Granted, I'd also be open to something like 200kW or even 240kW a core; although I was told by Liv that the 180-200kW range was accepted by the direction team.

## Technical details
<!-- Summary of code changes for easier review. -->
`2000000f` -> `90000f` in `AmeNodeGroup`.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn an AME. Turn it on.
Look at the powergen.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Hopefully none this time!
We'll see though.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- tweak: The AME now generates 180kW per core, instead of 8MW.