### PR TITLE
Refactor Station Job Slot Allocation Method

### DIFF
--- a/Content.Client/StationRecords/GeneralStationRecordConsoleWindow.xaml.cs
+++ b/Content.Client/StationRecords/GeneralStationRecordConsoleWindow.xaml.cs
@@ -147,10 +147,16 @@ public sealed partial class GeneralStationRecordConsoleWindow : DefaultWindow
         if (state.RecordListing == null)
         {
             RecordListingStatus.Visible = true;
-            RecordListing.Visible = true;
             RecordListingStatus.Text = Loc.GetString("general-station-record-console-empty-state");
-            RecordContainer.Visible = true;
-            RecordContainerStatus.Visible = true;
+            // HardLight start
+            RecordListing.Clear();
+            RecordListing.ClearSelected();
+            RecordListing.Visible = false;
+
+            RecordContainer.RemoveAllChildren();
+            RecordContainer.Visible = false;
+            RecordContainerStatus.Visible = false;
+            // HardLight end
             return;
         }
 
@@ -159,20 +165,20 @@ public sealed partial class GeneralStationRecordConsoleWindow : DefaultWindow
         RecordContainer.Visible = true;
         PopulateRecordListing(state.RecordListing!, state.SelectedKey);
 
-        RecordContainerStatus.Visible = state.Record == null;
-
         if (state.Record != null)
         {
-            RecordContainerStatus.Visible = state.SelectedKey == null;
-            RecordContainerStatus.Text = state.SelectedKey == null
-                ? Loc.GetString("general-station-record-console-no-record-found")
-                : Loc.GetString("general-station-record-console-select-record-info");
+            RecordContainerStatus.Visible = false; // HardLight: state.SelectedKey == null<false
             PopulateRecordContainer(state.Record, state.CanDeleteEntries, state.SelectedKey);
+            return; // HardLight
         }
-        else
-        {
-            RecordContainer.RemoveAllChildren();
-        }
+
+        // HardLight start
+        RecordContainer.RemoveAllChildren();
+        RecordContainerStatus.Visible = true;
+        RecordContainerStatus.Text = state.SelectedKey == null
+            ? Loc.GetString("general-station-record-console-select-record-info")
+            : Loc.GetString("general-station-record-console-no-record-found");
+        // HardLight end
     }
     private void PopulateRecordListing(Dictionary<uint, string> listing, uint? selected)
     {

--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -172,10 +172,13 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
         var station = _station.GetOwningStation(ent);
         var name = Name(ent.Owner);
 
+        if (station is not { } stationUid) // HardLight
+            return;
+
         if (!TryComp<CryostorageComponent>(cryostorageEnt, out var cryostorageComponent))
             return;
 
-        // if we have a session, we use that to add back in all the job slots the player had.
+        // If we have a session, we use that to add back in all the job slots the player had.
         if (userId != null)
         {
             foreach (var uniqueStation in _station.GetStationsSet())
@@ -220,21 +223,18 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
         UpdateCryostorageUIState((cryostorageEnt.Value, cryostorageComponent));
         AdminLog.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(ent):player} was entered into cryostorage inside of {ToPrettyString(cryostorageEnt.Value)}");
 
-        if (!TryComp<StationRecordsComponent>(station, out var stationRecords))
-            return;
-
         var jobName = Loc.GetString("earlyleave-cryo-job-unknown");
-        var recordId = _stationRecords.GetRecordByName(station.Value, name);
+        var recordId = _stationRecords.GetRecordByName(stationUid, name); // HardLight: station.Value<stationUid
         if (recordId != null)
         {
-            var key = new StationRecordKey(recordId.Value, station.Value);
-            if (_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var entry, stationRecords))
+            var key = new StationRecordKey(recordId.Value, stationUid); // HardLight: station.Value<stationUid
+            if (_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var entry)) // HardLight: Removed stationRecords
                 jobName = entry.JobTitle;
 
-            _stationRecords.RemoveRecord(key, stationRecords);
+            _stationRecords.RemoveRecord(key); // HardLight: Removed stationRecords
         }
 
-        _chatSystem.DispatchStationAnnouncement(station.Value,
+        _chatSystem.DispatchStationAnnouncement(stationUid, // HardLight: station.Value<stationUid
             Loc.GetString(
                 "earlyleave-cryo-announcement",
                 ("character", name),
@@ -251,7 +251,7 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
         if (!CryoSleepRejoiningEnabled || !IsInPausedMap(uid))
             return;
 
-        // how did you destroy these? they're indestructible.
+        // How did you destroy these? they're indestructible.
         if (comp.Cryostorage is not { } cryostorage ||
             TerminatingOrDeleted(cryostorage) ||
             !TryComp<CryostorageComponent>(cryostorage, out var cryostorageComponent))

--- a/Content.Server/CartridgeLoader/Cartridges/PsiWatchCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/PsiWatchCartridgeSystem.cs
@@ -52,10 +52,10 @@ public sealed class PsiWatchCartridgeSystem : EntitySystem
         if (_station.GetOwningStation(loader) is { } station)
             ent.Comp.Station = station;
 
-        if (!TryComp<StationRecordsComponent>(ent.Comp.Station, out var records))
+        if (!_records.TryGetAuthoritativeRecords(out var authorityStation, out var records)) // HardLight: TryComp<StationRecordsComponent>(ent.Comp.Station<_records.TryGetAuthoritativeRecords(out var authorityStation
             return;
 
-        station = ent.Comp.Station.Value;
+        station = authorityStation; // HardLight: ent.Comp.Station.Value<authorityStation
 
         var entries = new List<PsiWatchEntry>();
         foreach (var (id, criminal) in _records.GetRecordsOfType<PsionicsRecord>(station, records))

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
@@ -15,7 +15,6 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Security.Components;
 using System.Linq;
 using Content.Shared.Roles.Jobs;
-using Content.Server._NF.SectorServices; // Frontier
 
 namespace Content.Server.CriminalRecords.Systems;
 
@@ -29,9 +28,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RadioSystem _radio = default!;
     [Dependency] private readonly StationRecordsSystem _records = default!;
-    // [Dependency] private readonly StationSystem _station = default!; // Frontier
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly SectorServiceSystem _sectorService = default!; // Frontier
 
     public override void Initialize()
     {
@@ -208,9 +205,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
     private void UpdateUserInterface(Entity<CriminalRecordsConsoleComponent> ent)
     {
         var (uid, console) = ent;
-        var owningStation = _sectorService.GetServiceEntity(); // Frontier: _station.GetOwningStation < _sectorService.GetServiceEntity
-
-        if (!TryComp<StationRecordsComponent>(owningStation, out var stationRecords))
+        if (!_records.TryGetAuthoritativeRecords(out var owningStation, out var stationRecords)) // HardLight: TryComp<StationRecordsComponent><_records.TryGetAuthoritativeRecords; added out var
         {
             _ui.SetUiState(uid, CriminalRecordsConsoleKey.Key, new CriminalRecordsConsoleState());
             return;
@@ -220,7 +215,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         var listing = _records.BuildListing((owningStation, stationRecords), console.Filter); // Frontier: owningStation.Value<owningStation
 
         // filter the listing by the selected criminal record status
-        //if NONE, dont filter by status, just show all crew
+        // if NONE, dont filter by status, just show all crew
         if (console.FilterStatus != SecurityStatus.None)
         {
             listing = listing
@@ -263,15 +258,8 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         if (ent.Comp.ActiveKey is not { } id)
             return false;
 
-        // Frontier: sector-wide records
-        // checking the console's station since the user might be off-grid using on-grid console
-        // if (_station.GetOwningStation(ent) is not { } station)
-        //     return false;
-        var station = _sectorService.GetServiceEntity();
-
-        if (!TryComp<StationRecordsComponent>(station, out var stationRecords))
+        if (!_records.TryGetAuthoritativeRecords(out var station, out var stationRecords)) // HardLight
             return false;
-        // End Frontier
 
         key = new StationRecordKey(id, station);
         mob = user;

--- a/Content.Server/Delivery/DeliverySystem.Spawning.cs
+++ b/Content.Server/Delivery/DeliverySystem.Spawning.cs
@@ -51,7 +51,7 @@ public sealed partial class DeliverySystem
 
     private void AdjustStationDeliveries(Entity<CargoDeliveryDataComponent> ent)
     {
-        if (!TryComp<StationRecordsComponent>(ent, out var records))
+        if (!_records.TryGetAuthoritativeRecords(out var recordsStation, out _)) // HardLight: Editted
             return;
 
         var spawners = GetValidSpawners(ent);
@@ -61,12 +61,20 @@ public sealed partial class DeliverySystem
             return;
 
         // Skip if there's nobody in crew manifest
-        if (records.Records.Keys.Count == 0)
+        // HardLight start
+        var recordCount = 0;
+        foreach (var _ in _records.GetRecordsOfType<GeneralStationRecord>(recordsStation))
+        {
+            recordCount++;
+        }
+
+        if (recordCount == 0) // records.Records.Keys.Count<recordCount
+        // HardLight end
             return;
 
         // We take the amount of mail calculated based on player amount or the minimum, whichever is higher.
         // We don't want stations with less than the player ratio to not get mail at all
-        var initialDeliveryCount = (int)Math.Ceiling(records.Records.Keys.Count / ent.Comp.PlayerToDeliveryRatio);
+        var initialDeliveryCount = (int)Math.Ceiling(recordCount / ent.Comp.PlayerToDeliveryRatio); // HardLight: records.Records.Keys.Count<recordCount
         var deliveryCount = Math.Max(initialDeliveryCount, ent.Comp.MinimumDeliverySpawn);
 
         if (!ent.Comp.DistributeRandomly)

--- a/Content.Server/PsionicsRecords/Systems/PsionicsRecordsConsoleSystem.cs
+++ b/Content.Server/PsionicsRecords/Systems/PsionicsRecordsConsoleSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Popups;
 using Content.Server.Radio.EntitySystems;
-using Content.Server.Station.Systems;
 using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Access.Systems;
@@ -30,7 +29,6 @@ public sealed class PsionicsRecordsConsoleSystem : SharedPsionicsRecordsConsoleS
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RadioSystem _radio = default!;
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
-    [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
     public override void Initialize()
@@ -142,21 +140,19 @@ public sealed class PsionicsRecordsConsoleSystem : SharedPsionicsRecordsConsoleS
     private void UpdateUserInterface(Entity<PsionicsRecordsConsoleComponent> ent)
     {
         var (uid, console) = ent;
-        var owningStation = _station.GetOwningStation(uid);
-
-        if (!TryComp<StationRecordsComponent>(owningStation, out var stationRecords))
+        if (!_stationRecords.TryGetAuthoritativeRecords(out var owningStation, out var stationRecords)) // HardLight: TryComp<StationRecordsComponent><_stationRecords.TryGetAuthoritativeRecords; added out var
         {
             _ui.SetUiState(uid, PsionicsRecordsConsoleKey.Key, new PsionicsRecordsConsoleState());
             return;
         }
 
-        var listing = _stationRecords.BuildListing((owningStation.Value, stationRecords), console.Filter);
+        var listing = _stationRecords.BuildListing((owningStation, stationRecords), console.Filter); // HardLight: owningStation.Value<owningStation
 
         var state = new PsionicsRecordsConsoleState(listing, console.Filter);
         if (console.ActiveKey is { } id)
         {
             // get records to display when a crewmember is selected
-            var key = new StationRecordKey(id, owningStation.Value);
+            var key = new StationRecordKey(id, owningStation); // HardLight: owningStation.Value<owningStation
             _stationRecords.TryGetRecord(key, out state.StationRecord, stationRecords);
             _stationRecords.TryGetRecord(key, out state.PsionicsRecord, stationRecords);
             state.SelectedKey = id;
@@ -184,8 +180,7 @@ public sealed class PsionicsRecordsConsoleSystem : SharedPsionicsRecordsConsoleS
         if (ent.Comp.ActiveKey is not { } id)
             return false;
 
-        // checking the console's station since the user might be off-grid using on-grid console
-        if (_station.GetOwningStation(ent) is not { } station)
+        if (!_stationRecords.TryGetAuthoritativeRecords(out var station, out _)) // HardLight: Editted
             return false;
 
         key = new StationRecordKey(id, station);
@@ -211,14 +206,11 @@ public sealed class PsionicsRecordsConsoleSystem : SharedPsionicsRecordsConsoleS
     public void CheckNewIdentity(EntityUid uid)
     {
         var name = Identity.Name(uid, EntityManager);
-        var xform = Transform(uid);
 
-        // TODO use the entity's station? Not the station of the map that it happens to currently be on?
-        var station = _station.GetStationInMap(xform.MapID);
-
-        if (station != null && _stationRecords.GetRecordByName(station.Value, name) is { } id)
+        if (_stationRecords.TryGetAuthoritativeRecords(out var station, out _) // HardLight
+            && _stationRecords.GetRecordByName(station, name) is { } id)
         {
-            if (_stationRecords.TryGetRecord<PsionicsRecord>(new StationRecordKey(id, station.Value),
+            if (_stationRecords.TryGetRecord<PsionicsRecord>(new StationRecordKey(id, station), // HardLight: station.Value<station
                     out var record))
             {
                 if (record.Status != PsionicsStatus.None)

--- a/Content.Server/Shuttles/Components/StationColcommComponent.cs
+++ b/Content.Server/Shuttles/Components/StationColcommComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Roles; // HardLight
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes; // HardLight
 using Robust.Shared.Utility;
 
 namespace Content.Server.Shuttles.Components;
@@ -26,4 +28,12 @@ public sealed partial class StationColcommComponent : Component
 
     [DataField]
     public EntityUid? MapEntity;
+
+    /// <summary>
+    /// HardLight: Job registry configuration used to seed
+    /// on the persistent ColComm grid entity.
+    /// Format: key = job prototype ID, value = [roundStartSlots, midRoundMaxSlots] (negative = unlimited).
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, int[]> JobRegistryConfig = new();
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -68,6 +68,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly Content.Server._HL.ColComm.ColcommJobSystem _colcommJobs = default!; // HardLight
 
     private const float ShuttleSpawnBuffer = 1f;
 
@@ -547,6 +548,14 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         _metaData.SetEntityName(map, Loc.GetString("map-name-Colcomm"));
         _shuttle.TryAddFTLDestination(mapId, true, out _);
         Log.Info($"Created Colcomm grid {ToPrettyString(grid)} on map {ToPrettyString(map)} for station {ToPrettyString(station)}");
+
+        // HardLight: Seed the persistent job registry on the ColComm grid entity.
+        // SetupColcommRegistry handles the [Access] boundary for ConfiguredJobs.
+        if (component.JobRegistryConfig.Count > 0)
+        {
+            var colcommRegistry = EnsureComp<Content.Server._HL.ColComm.ColcommJobRegistryComponent>(grid.Value);
+            _colcommJobs.SetupColcommRegistry((grid.Value, colcommRegistry), component.JobRegistryConfig);
+        }
     }
 
     public HashSet<EntityUid> GetColcommMaps()

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -283,7 +283,7 @@ public sealed partial class StationJobsSystem
 
         foreach (var job in jobs.Distinct())
         {
-            var count = _jobTracking.GetNumberOfActiveRoles(job, includeAfk: true);
+            var count = _jobTracking.GetNumberOfActiveRoles(job, includeAfk: true, includeOutsideDefaultMap: true); // HardLight: Added includeOutsideDefaultMap: true
             if (count > 0)
                 counts[job] = count;
         }

--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Server._NF.Station.Components;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
@@ -25,6 +26,7 @@ namespace Content.Server.Station.Systems;
 public sealed partial class StationJobsSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly ColcommJobSystem _colcommJobs = default!; // HardLight
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
@@ -108,6 +110,34 @@ public sealed partial class StationJobsSystem : EntitySystem
     {
         if (!Resolve(station, ref stationJobs, false))
             return false;
+
+        // HardLight start
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm)
+            && IsConfiguredJob(station, jobPrototypeId, stationJobs))
+        {
+            if (_colcommJobs.IsPlayerJobTracked(colcomm, netUserId, jobPrototypeId))
+                return true;
+
+            if (!_colcommJobs.TryGetJobSlot(colcomm, jobPrototypeId, out var globalSlots))
+                return false;
+
+            if (globalSlots == 0)
+                return false;
+
+            if (!_colcommJobs.TryAdjustJobSlot(colcomm, jobPrototypeId, -1, clamp: true))
+                return false;
+
+            _colcommJobs.TryTrackPlayerJob(colcomm, netUserId, jobPrototypeId);
+
+            if (!IsPlayerJobTracked(station, netUserId, jobPrototypeId, stationJobs))
+            {
+                TryAdjustJobSlot(station, jobPrototypeId, -1, false, true, stationJobs);
+                TryTrackPlayerJob(station, netUserId, jobPrototypeId, stationJobs);
+            }
+
+            return true;
+        }
+        // HardLight end
 
         if (!TryAdjustJobSlot(station, jobPrototypeId, -1, false, false, stationJobs))
             return false;
@@ -268,6 +298,74 @@ public sealed partial class StationJobsSystem : EntitySystem
     }
 
     /// <summary>
+    /// HardLight: Returns true when the given job is present in the station's configured job list
+    /// (<see cref="StationJobsComponent.SetupAvailableJobs"/>).  Use this from systems that only
+    /// have Read access to <see cref="StationJobsComponent"/> to avoid RA0002 violations.
+    /// </summary>
+    public bool IsConfiguredJob(EntityUid station,
+        ProtoId<JobPrototype> jobPrototypeId,
+        StationJobsComponent? stationJobs = null)
+    {
+        if (!Resolve(station, ref stationJobs, false))
+            return false;
+
+        return stationJobs.SetupAvailableJobs.ContainsKey(jobPrototypeId);
+    }
+
+    /// <summary>
+    /// HardLight: Returns true if this station already tracks the given player's assignment for the job.
+    /// </summary>
+    public bool IsPlayerJobTracked(EntityUid station,
+        NetUserId userId,
+        ProtoId<JobPrototype> jobPrototypeId,
+        StationJobsComponent? stationJobs = null)
+    {
+        if (!Resolve(station, ref stationJobs, false))
+            return false;
+
+        return stationJobs.PlayerJobs.TryGetValue(userId, out var jobs) && jobs.Contains(jobPrototypeId);
+    }
+
+    /// <summary>
+    /// HardLight: Ensures this station tracks the given player's assignment for the job.
+    /// </summary>
+    public bool TryTrackPlayerJob(EntityUid station,
+        NetUserId userId,
+        ProtoId<JobPrototype> jobPrototypeId,
+        StationJobsComponent? stationJobs = null)
+    {
+        if (!Resolve(station, ref stationJobs, false))
+            return false;
+
+        stationJobs.PlayerJobs.TryAdd(userId, new());
+        if (!stationJobs.PlayerJobs[userId].Contains(jobPrototypeId))
+            stationJobs.PlayerJobs[userId].Add(jobPrototypeId);
+
+        return true;
+    }
+
+    /// <summary>
+    /// HardLight: Removes this player's assignment tracking for the given job on the station.
+    /// </summary>
+    public bool TryUntrackPlayerJob(EntityUid station,
+        NetUserId userId,
+        ProtoId<JobPrototype> jobPrototypeId,
+        StationJobsComponent? stationJobs = null)
+    {
+        if (!Resolve(station, ref stationJobs, false))
+            return false;
+
+        if (!stationJobs.PlayerJobs.TryGetValue(userId, out var jobs))
+            return false;
+
+        jobs.Remove(jobPrototypeId);
+        if (jobs.Count == 0)
+            stationJobs.PlayerJobs.Remove(userId);
+
+        return true;
+    }
+
+    /// <summary>
     /// HardLight: Attempts to set the configured mid-round maximum slots for a job in <see cref="StationJobsComponent.SetupAvailableJobs"/>.
     /// This controls logic that references setup max values (e.g. job reopening checks).
     /// </summary>
@@ -358,6 +456,13 @@ public sealed partial class StationJobsSystem : EntitySystem
         if (!Resolve(station, ref stationJobs))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
 
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm) // HardLight
+            && stationJobs.SetupAvailableJobs.ContainsKey(jobPrototypeId)
+            && _colcommJobs.TryGetJobSlot(colcomm, jobPrototypeId, out var globalJob))
+        {
+            return globalJob == null;
+        }
+
         return stationJobs.JobList.TryGetValue(jobPrototypeId, out var job) && job == null;
     }
 
@@ -386,6 +491,14 @@ public sealed partial class StationJobsSystem : EntitySystem
         if (!Resolve(station, ref stationJobs))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
 
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm) // HardLight
+            && stationJobs.SetupAvailableJobs.ContainsKey(jobPrototypeId)
+            && _colcommJobs.TryGetJobSlot(colcomm, jobPrototypeId, out var globalSlots))
+        {
+            slots = globalSlots;
+            return true;
+        }
+
         return stationJobs.JobList.TryGetValue(jobPrototypeId, out slots);
     }
 
@@ -400,6 +513,13 @@ public sealed partial class StationJobsSystem : EntitySystem
     {
         if (!Resolve(station, ref stationJobs))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
+
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm)) // HardLight
+        {
+            return stationJobs.SetupAvailableJobs.Keys
+                .Where(job => _colcommJobs.TryGetJobSlot(colcomm, job, out var slots) && slots != 0)
+                .ToArray();
+        }
 
         return stationJobs.JobList
             .Where(x => x.Value != 0)
@@ -432,6 +552,14 @@ public sealed partial class StationJobsSystem : EntitySystem
     {
         if (!Resolve(station, ref stationJobs))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
+
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm)) // HardLight
+        {
+            return stationJobs.SetupAvailableJobs.Keys
+                .Select(job => (job, found: _colcommJobs.TryGetJobSlot(colcomm, job, out var slots), slots))
+                .Where(entry => entry.found)
+                .ToDictionary(entry => entry.job, entry => entry.slots);
+        }
 
         return stationJobs.JobList;
     }
@@ -540,7 +668,7 @@ public sealed partial class StationJobsSystem : EntitySystem
         while (query.MoveNext(out var station, out var comp))
         {
             var stationNetEntity = GetNetEntity(station);
-            var list = comp.JobList.ToDictionary(x => x.Key, x => x.Value);
+            var list = GetJobs(station, comp).ToDictionary(x => x.Key, x => x.Value); // HardLight: Editted
 
             // Frontier: overwrite station/vessel information generation
             var isLateJoinStation = false;

--- a/Content.Server/StationEvents/Events/ClericalErrorRule.cs
+++ b/Content.Server/StationEvents/Events/ClericalErrorRule.cs
@@ -19,10 +19,18 @@ public sealed class ClericalErrorRule : StationEventSystem<ClericalErrorRuleComp
         if (!TryGetRandomStation(out var chosenStation))
             return;
 
-        if (!TryComp<StationRecordsComponent>(chosenStation, out var stationRecords))
+        if (!_stationRecords.TryGetAuthoritativeRecords(out var station, out _)) // HardLight: Editted
             return;
 
-        var recordCount = stationRecords.Records.Keys.Count;
+        // HardLight start
+        var allIds = new List<uint>();
+        foreach (var (id, _) in _stationRecords.GetRecordsOfType<GeneralStationRecord>(station))
+        {
+            allIds.Add(id);
+        }
+
+        var recordCount = allIds.Count;
+        // HardLight end
 
         if (recordCount == 0)
             return;
@@ -33,13 +41,13 @@ public sealed class ClericalErrorRule : StationEventSystem<ClericalErrorRuleComp
         var keys = new List<uint>();
         for (var i = 0; i < toRemove; i++)
         {
-            keys.Add(RobustRandom.Pick(stationRecords.Records.Keys));
+            keys.Add(RobustRandom.Pick(allIds)); // HardLight: stationRecords.Records.Keys<allIds
         }
 
         foreach (var id in keys)
         {
-            var key = new StationRecordKey(id, chosenStation.Value);
-            _stationRecords.RemoveRecord(key, stationRecords);
+            var key = new StationRecordKey(id, station); // HardLight: chosenStation.Value<stationRecords
+            _stationRecords.RemoveRecord(key); // HardLight: Removed stationRecords
         }
     }
 }

--- a/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
+++ b/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords.Components;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Shared.StationRecords;
 using Robust.Server.GameObjects;
 using Content.Shared.Roles; // Frontier
@@ -20,6 +21,7 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly StationJobsSystem _stationJobsSystem = default!; // Frontier
+    [Dependency] private readonly ColcommJobSystem _colcommJobs = default!; // HardLight
     [Dependency] private readonly AccessReaderSystem _access = default!; // Frontier
     [Dependency] private readonly IPrototypeManager _proto = default!; // Frontier
     [Dependency] private readonly IAdminLogManager _adminLog = default!; // Frontier
@@ -46,10 +48,9 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         if (!ent.Comp.CanDeleteEntries)
             return;
 
-        var owning = _station.GetOwningStation(ent.Owner);
+        if (_stationRecords.TryGetAuthoritativeRecords(out var recordsStation, out _)) // HardLight
+            _stationRecords.RemoveRecord(new StationRecordKey(args.Id, recordsStation));
 
-        if (owning != null)
-            _stationRecords.RemoveRecord(new StationRecordKey(args.Id, owning.Value));
         UpdateUserInterface(ent); // Apparently an event does not get raised for this.
     }
 
@@ -67,13 +68,13 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         UpdateUserInterface(ent);
     }
 
-    // Frontier: job counts, advertisements
+    // Frontier: Job counts, advertisements
     private void OnAdjustJob(Entity<GeneralStationRecordConsoleComponent> ent, ref AdjustStationJobMsg msg)
     {
         var stationUid = _station.GetOwningStation(ent);
         if (stationUid is EntityUid station)
         {
-            // Frontier: check access - hack because we don't have an AccessReaderComponent, it's the station
+            // Frontier start: Check access; hack because we don't have an AccessReaderComponent, it's the station
             if (TryComp(stationUid, out StationJobsComponent? stationJobs) &&
                 (stationJobs.Groups.Count > 0 || stationJobs.Tags.Count > 0))
             {
@@ -101,8 +102,13 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
                     return;
                 }
             }
-            // End Frontier
-            _stationJobsSystem.TryAdjustJobSlot(station, msg.JobProto, msg.Amount, false, true);
+            // Frontier end
+            if (_colcommJobs.TryGetColcommRegistry(out var colcomm)) // HardLight
+            {
+                _colcommJobs.TryAdjustJobSlot(colcomm, msg.JobProto, msg.Amount, clamp: true);
+                _stationJobsSystem.UpdateJobsAvailable();
+            }
+
             UpdateUserInterface(ent);
         }
     }
@@ -138,20 +144,22 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         // Frontier: jobs, advertisements
         IReadOnlyDictionary<ProtoId<JobPrototype>, int?>? jobList = null;
         string? advertisement = null;
+        if (_colcommJobs.TryGetColcommRegistry(out var colcomm)) // HardLight
+            jobList = colcomm.Comp.CurrentSlots;
+
         if (owningStation != null)
         {
-            jobList = _stationJobsSystem.GetJobs(owningStation.Value);
             if (TryComp<ExtraShuttleInformationComponent>(owningStation, out var extraVessel))
                 advertisement = extraVessel.Advertisement;
         }
 
-        if (!TryComp<StationRecordsComponent>(owningStation, out var stationRecords))
+        if (!_stationRecords.TryGetAuthoritativeRecords(out var stationUid, out var stationRecords)) // HardLight: TryComp<StationRecordsComponent>(owningStation<_stationRecords.TryGetAuthoritativeRecords; added out var stationUid
         {
             _ui.SetUiState(uid, GeneralStationRecordConsoleKey.Key, new GeneralStationRecordConsoleState(null, null, null, jobList, console.Filter, ent.Comp.CanDeleteEntries, advertisement)); // Frontier: add as many args as we can
             return;
         }
 
-        var listing = _stationRecords.BuildListing((owningStation.Value, stationRecords), console.Filter);
+        var listing = _stationRecords.BuildListing((stationUid, stationRecords), console.Filter); // HardLight: owningStation.Value<stationUid
 
         switch (listing.Count)
         {
@@ -171,7 +179,7 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
             return;
         }
 
-        var key = new StationRecordKey(id, owningStation.Value);
+        var key = new StationRecordKey(id, stationUid); // HardLight: owningStation.Value<stationUid
         _stationRecords.TryGetRecord<GeneralStationRecord>(key, out var record, stationRecords);
 
         GeneralStationRecordConsoleState newState = new(id, record, listing, jobList, console.Filter, ent.Comp.CanDeleteEntries, advertisement);

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -1,11 +1,14 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Server._NF.SectorServices; // Frontier
 using Content.Server.Access.Systems;
 using Content.Server.Forensics;
 using Content.Shared.Access.Components;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
+using Content.Shared.Humanoid; // HardLight
 using Content.Shared.Inventory;
+using Content.Shared._NF.Roles.Components; // HardLight
 using Content.Shared.PDA;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
@@ -53,14 +56,12 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
         SubscribeLocalEvent<EntityRenamedEvent>(OnRename);
+        SubscribeLocalEvent<ColcommRegistryRoundStartEvent>(OnColcommRoundStart); // HardLight
     }
 
     private void OnPlayerSpawn(PlayerSpawnCompleteEvent args)
     {
-        if (!TryComp<StationRecordsComponent>(args.Station, out var stationRecords))
-            return;
-
-        CreateGeneralRecord(args.Station, args.Mob, args.Profile, args.JobId, stationRecords);
+        CreateGeneralRecord(args.Station, args.Mob, args.Profile, args.JobId); // HardLight: Removed stationRecords
     }
 
     private void OnRename(ref EntityRenamedEvent ev)
@@ -88,8 +89,26 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         }
     }
 
+    /// <summary>
+    /// HardLight: Gets the single authoritative records store used by cross-round consoles and systems.
+    /// </summary>
+    public bool TryGetAuthoritativeRecords(
+        out EntityUid stationUid,
+        [NotNullWhen(true)] out StationRecordsComponent? stationRecords)
+    {
+        stationUid = _sectorService.GetServiceEntity();
+        if (stationUid == EntityUid.Invalid || !TryComp<StationRecordsComponent>(stationUid, out stationRecords))
+        {
+            stationUid = EntityUid.Invalid;
+            stationRecords = null;
+            return false;
+        }
+
+        return true;
+    }
+
     public void CreateGeneralRecord(EntityUid station, EntityUid player, HumanoidCharacterProfile profile,
-        string? jobId, StationRecordsComponent records) // Frontier: private<public
+        string? jobId) // HardLight: Removed StationRecordsComponent records
     {
         // TODO make PlayerSpawnCompleteEvent.JobId a ProtoId
         if (string.IsNullOrEmpty(jobId)
@@ -102,31 +121,35 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         TryComp<FingerprintComponent>(player, out var fingerprintComponent);
         TryComp<DnaComponent>(player, out var dnaComponent);
 
-        CreateGeneralRecord(station, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
-
-        /// Frontier: generate sector-wide station record
+        /// Frontier start: Generate sector-wide station record
         if (TryComp<SpecialSectorStationRecordComponent>(player, out var specialRecord) && specialRecord.RecordGeneration == RecordGenerationType.NoRecord)
             return;
 
-        EntityUid serviceEnt = _sectorService.GetServiceEntity();
+        if (!TryGetAuthoritativeRecords(out var serviceEnt, out var stationRecords))
+            return;
 
-        if (TryComp(serviceEnt, out StationRecordsComponent? stationRecords))
+        // HardLight: Checks if certain information should be faked, if so, fake it.
+        string playerJob = jobId;
+        string? fingerprint = fingerprintComponent?.Fingerprint;
+        string? dna = dnaComponent?.DNA;
+        if (specialRecord != null
+            && specialRecord.RecordGeneration == RecordGenerationType.FalseRecord)
         {
-            //Checks if certain information should be faked, if so, fake it.
-            string playerJob = jobId;
-            string? fingerprint = fingerprintComponent?.Fingerprint;
-            string? dna = dnaComponent?.DNA;
-            if (specialRecord != null
-                && specialRecord.RecordGeneration == RecordGenerationType.FalseRecord)
-            {
-                playerJob = _random.Pick(FakeJobIds);
-                fingerprint = _forensics.GenerateFingerprint();
-                dna = _forensics.GenerateDNA();
-            }
-
-            CreateGeneralRecord(serviceEnt, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, playerJob, fingerprint, dna, profile, stationRecords);
+            playerJob = _random.Pick(FakeJobIds);
+            fingerprint = _forensics.GenerateFingerprint();
+            dna = _forensics.GenerateDNA();
         }
-        /// End Frontier
+
+        CreateGeneralRecord(serviceEnt, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, playerJob, fingerprint, dna, profile, stationRecords);
+
+        // HardLight: Mirror the record key onto the character so lifecycle cleanup can remove stale records
+        // even when the ID card moves away or is deleted separately.
+        if (TryComp<StationRecordKeyStorageComponent>(idUid.Value, out var keyStorage)
+            && keyStorage.Key is { } key)
+        {
+            SetEntityKey(player, key);
+        }
+        /// Frontier end
     }
 
 
@@ -246,23 +269,95 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     }
 
     /// <summary>
-    ///     Removes a record from this station.
+    /// HardLight: Set the station records key for an entity that should be treated as the character owner of a record.
+    /// </summary>
+    public void SetEntityKey(EntityUid uid, StationRecordKey key)
+    {
+        _keyStorage.AssignKey(uid, key);
+    }
+
+    /// <summary>
+    /// HardLight: At round restart, clear stale records and rebuild from all currently-active tracked crew.
+    /// This ensures persisted characters appear immediately without waiting for a spawn event.
+    /// </summary>
+    private void OnColcommRoundStart(ColcommRegistryRoundStartEvent ev)
+    {
+        if (!TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+            return;
+
+        // Clear all existing records in O(1) by replacing the set.
+        authorityRecords.Records = new StationRecordSet();
+
+        // Rebuild from every currently active tracked crew member.
+        var jobQuery = AllEntityQuery<JobTrackingComponent>();
+        while (jobQuery.MoveNext(out var uid, out var job))
+        {
+            if (!job.Active || job.Job is not { } jobId)
+                continue;
+
+            if (!_prototypeManager.TryIndex<JobPrototype>(jobId, out var jobPrototype))
+                continue;
+
+            var name = MetaData(uid).EntityName;
+            if (name.Length == 0)
+                continue;
+
+            TryComp<HumanoidAppearanceComponent>(uid, out var humanoid);
+            TryComp<FingerprintComponent>(uid, out var fingerprint);
+            TryComp<DnaComponent>(uid, out var dna);
+
+            var record = new GeneralStationRecord()
+            {
+                Name = name,
+                Age = humanoid?.Age ?? 18,
+                JobTitle = jobPrototype.LocalizedName,
+                JobIcon = jobPrototype.Icon,
+                JobPrototype = jobId,
+                Species = humanoid?.Species ?? "Human",
+                Gender = humanoid?.Gender ?? Gender.Epicene,
+                DisplayPriority = jobPrototype.RealDisplayWeight,
+                Fingerprint = fingerprint?.Fingerprint,
+                DNA = dna?.DNA,
+            };
+
+            var id = authorityRecords.Records.AddRecordEntry(record);
+            if (id == null)
+                continue;
+
+            SetEntityKey(uid, new StationRecordKey(id.Value, authority));
+        }
+    }
+
+    /// <summary>
+    /// Removes a record from this station.
     /// </summary>
     /// <param name="key">The station and key to remove.</param>
     /// <param name="records">Station records component.</param>
     /// <returns>True if the record was removed, false otherwise.</returns>
     public bool RemoveRecord(StationRecordKey key, StationRecordsComponent? records = null)
     {
+        // HardLight: Prefer authoritative dataset for all removals.
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+        {
+            var authoritativeKey = key.OriginStation == authority ? key : new StationRecordKey(key.Id, authority);
+            if (authorityRecords.Records.RemoveAllRecords(authoritativeKey.Id))
+            {
+                RaiseLocalEvent(new RecordRemovedEvent(authoritativeKey));
+                return true;
+            }
+        }
+
+        // HardLight: Backward compatibility fallback.
         if (!Resolve(key.OriginStation, ref records))
             return false;
 
-        if (records.Records.RemoveAllRecords(key.Id))
-        {
-            RaiseLocalEvent(new RecordRemovedEvent(key));
-            return true;
-        }
+        // HardLight start: Slightly edited.
+        if (!records.Records.RemoveAllRecords(key.Id))
+            return false;
 
-        return false;
+        RaiseLocalEvent(new RecordRemovedEvent(key));
+        return true;
+        // HardLight end
     }
 
     /// <summary>
@@ -299,7 +394,7 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     }
 
     /// <summary>
-    ///     Adds a new record entry to a station's record set.
+    /// Adds a new record entry to a station's record set.
     /// </summary>
     /// <param name="station">The station to add the record to.</param>
     /// <param name="record">The record to add.</param>
@@ -307,14 +402,24 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     /// <typeparam name="T">The type of record to add.</typeparam>
     public StationRecordKey AddRecordEntry<T>(EntityUid station, T record, StationRecordsComponent? records = null)
     {
+        // HardLight: Authoritative writes first.
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+        {
+            var id = authorityRecords.Records.AddRecordEntry(record);
+            if (id == null)
+                return StationRecordKey.Invalid;
+
+            return new StationRecordKey(id.Value, authority);
+        }
+
         if (!Resolve(station, ref records))
             return StationRecordKey.Invalid;
 
-        var id = records.Records.AddRecordEntry(record);
-        if (id == null)
+        var fallbackId = records.Records.AddRecordEntry(record);
+        if (fallbackId == null)
             return StationRecordKey.Invalid;
 
-        return new StationRecordKey(id.Value, station);
+        return new StationRecordKey(fallbackId.Value, station);
     }
 
     /// <summary>
@@ -327,6 +432,14 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     public void AddRecordEntry<T>(StationRecordKey key, T record,
         StationRecordsComponent? records = null)
     {
+        // HardLight: Authoritative writes first.
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+        {
+            var authoritativeKey = key.OriginStation == authority ? key : new StationRecordKey(key.Id, authority);
+            authorityRecords.Records.AddRecordEntry(authoritativeKey.Id, record);
+            return;
+        }
+
         if (!Resolve(key.OriginStation, ref records))
             return;
 
@@ -340,6 +453,18 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     /// <param name="records">Station records component.</param>
     public void Synchronize(EntityUid station, StationRecordsComponent? records = null)
     {
+        // HardLight: Authoritative synchronization first.
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+        {
+            foreach (var key in authorityRecords.Records.GetRecentlyAccessed())
+            {
+                RaiseLocalEvent(new RecordModifiedEvent(new StationRecordKey(key, authority)));
+            }
+
+            authorityRecords.Records.ClearRecentlyAccessed();
+            return;
+        }
+
         if (!Resolve(station, ref records))
             return;
 
@@ -358,6 +483,15 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     /// <param name="records">Station records component.</param>
     public void Synchronize(StationRecordKey key, StationRecordsComponent? records = null)
     {
+        // HardLight: Authoritative synchronization first.
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+        {
+            var authoritativeKey = key.OriginStation == authority ? key : new StationRecordKey(key.Id, authority);
+            RaiseLocalEvent(new RecordModifiedEvent(authoritativeKey));
+            authorityRecords.Records.RemoveFromRecentlyAccessed(authoritativeKey.Id);
+            return;
+        }
+
         if (!Resolve(key.OriginStation, ref records))
             return;
 
@@ -408,7 +542,12 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     {
         var listing = new Dictionary<uint, string>();
 
-        var records = GetRecordsOfType<GeneralStationRecord>(station, station.Comp);
+        // HardLight start: Build listings from the authoritative dataset whenever available.
+        var records = TryGetAuthoritativeRecords(out var authority, out var authorityRecords)
+            ? GetRecordsOfType<GeneralStationRecord>(authority, authorityRecords)
+            : GetRecordsOfType<GeneralStationRecord>(station, station.Comp);
+        // HardLight end
+
         foreach (var pair in records)
         {
             if (IsSkipped(filter, pair.Item2))
@@ -418,6 +557,41 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         }
 
         return listing;
+    }
+
+    // HardLight: Resolve lookups against authoritative records while keeping legacy station-local keys readable.
+    public new bool TryGetRecord<T>(StationRecordKey key, [NotNullWhen(true)] out T? entry, StationRecordsComponent? records = null)
+    {
+        // First try the provided/original key so legacy station-local keys keep working during migration.
+        if (base.TryGetRecord(key, out entry, records))
+            return true;
+
+        if (!TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+            return false;
+
+        if (key.OriginStation == authority)
+            return false;
+
+        var authoritativeKey = new StationRecordKey(key.Id, authority);
+        return base.TryGetRecord(authoritativeKey, out entry, authorityRecords);
+    }
+
+    // HardLight: Enumerate from authoritative records first so manifests are unified across all consumers.
+    public new IEnumerable<(uint, T)> GetRecordsOfType<T>(EntityUid station, StationRecordsComponent? records = null)
+    {
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+            return base.GetRecordsOfType<T>(authority, authorityRecords);
+
+        return base.GetRecordsOfType<T>(station, records);
+    }
+
+    // HardLight: Name-based queries should target authoritative records to avoid split datasets.
+    public new uint? GetRecordByName(EntityUid station, string name, StationRecordsComponent? records = null)
+    {
+        if (TryGetAuthoritativeRecords(out var authority, out var authorityRecords))
+            return base.GetRecordByName(authority, name, authorityRecords);
+
+        return base.GetRecordByName(station, name, records);
     }
 
     #endregion

--- a/Content.Server/_HL/ColComm/ColcommJobRegistryComponent.cs
+++ b/Content.Server/_HL/ColComm/ColcommJobRegistryComponent.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._HL.ColComm;
+
+/// <summary>
+/// Attached to the persistent Colonial Command grid entity.
+/// Serves as the server-wide, cross-round authoritative job registry.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ColcommJobSystem))]
+public sealed partial class ColcommJobRegistryComponent : Component
+{
+    /// <summary>
+    /// Master job configuration: key = job prototype ID, value = [roundStartSlots, midRoundMaxSlots].
+    /// Negative values mean unlimited (-1).
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, int[]> ConfiguredJobs = new();
+
+    /// <summary>
+    /// Currently available slot counts. Null = unlimited.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, int?> CurrentSlots = new();
+
+    /// <summary>
+    /// The configured mid-round maximum for each job.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, int> MidRoundMaxSlots = new();
+
+    /// <summary>
+    /// Tracks which players are occupying which jobs, to prevent double slot consumption on reconnect.
+    /// </summary>
+    [DataField]
+    public Dictionary<NetUserId, HashSet<ProtoId<JobPrototype>>> PlayerJobs = new();
+}

--- a/Content.Server/_HL/ColComm/ColcommJobSystem.cs
+++ b/Content.Server/_HL/ColComm/ColcommJobSystem.cs
@@ -1,0 +1,174 @@
+using Content.Server.GameTicking.Events;
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._HL.ColComm;
+
+// Manages the Colonial Command job registry: the persistent, server-wide authoritative job slot tracker.
+// All job slot open/close operations route through this system instead of per-station.
+public sealed class ColcommJobSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStarting);
+    }
+
+    private void OnRoundStarting(RoundStartingEvent ev)
+    {
+        if (!TryGetColcommRegistry(out var colcomm))
+            return;
+
+        ResetToDefaults(colcomm);
+
+        // Let other systems deduct active role counts for
+        // crew that persisted from the previous round.
+        RaiseLocalEvent(new ColcommRegistryRoundStartEvent { Colcomm = colcomm });
+
+        Dirty(colcomm);
+    }
+
+    // First-time initialization from a freshly created ColComm entity.
+    public void InitRegistry(Entity<ColcommJobRegistryComponent> colcomm)
+    {
+        ResetToDefaults(colcomm);
+        Dirty(colcomm);
+    }
+
+    // Sets the job configuration on ColComm creation and initializes the registry.
+    public void SetupColcommRegistry(Entity<ColcommJobRegistryComponent> colcomm, Dictionary<ProtoId<JobPrototype>, int[]> configuredJobs)
+    {
+        if (colcomm.Comp.ConfiguredJobs.Count > 0)
+            return; // Already configured from a prior round. Do not overwrite.
+
+        colcomm.Comp.ConfiguredJobs = configuredJobs;
+        ResetToDefaults(colcomm);
+        Dirty(colcomm);
+    }
+
+    private void ResetToDefaults(Entity<ColcommJobRegistryComponent> colcomm)
+    {
+        var comp = colcomm.Comp;
+        comp.CurrentSlots.Clear();
+        comp.MidRoundMaxSlots.Clear();
+        comp.PlayerJobs.Clear();
+
+        foreach (var (job, slots) in comp.ConfiguredJobs)
+        {
+            var midRoundMax = slots.Length > 1 ? slots[1] : 0;
+            comp.CurrentSlots[job] = midRoundMax < 0 ? (int?)null : midRoundMax;
+            comp.MidRoundMaxSlots[job] = Math.Max(midRoundMax, 0);
+        }
+    }
+
+    // Deducts the given job counts from ColComm's current available slots.
+    // Should account for crew transitioning from the previous round.
+    public void DeductActiveRoles(Entity<ColcommJobRegistryComponent> colcomm, Dictionary<ProtoId<JobPrototype>, int> activeCounts)
+    {
+        foreach (var (job, count) in activeCounts)
+        {
+            if (!colcomm.Comp.CurrentSlots.TryGetValue(job, out var current) || current == null)
+                continue;
+
+            colcomm.Comp.CurrentSlots[job] = Math.Max(current.Value - count, 0);
+        }
+
+        Dirty(colcomm);
+    }
+
+    // Returns the ColComm grid entity that holds the registry, if one exists.
+    public bool TryGetColcommRegistry(out Entity<ColcommJobRegistryComponent> entity)
+    {
+        var query = AllEntityQuery<ColcommJobRegistryComponent>();
+        if (query.MoveNext(out var uid, out var comp))
+        {
+            entity = (uid, comp);
+            return true;
+        }
+
+        entity = default;
+        return false;
+    }
+
+    public bool IsConfiguredJob(Entity<ColcommJobRegistryComponent> colcomm, ProtoId<JobPrototype> jobId)
+        => colcomm.Comp.ConfiguredJobs.ContainsKey(jobId);
+
+    public bool TryGetJobSlot(Entity<ColcommJobRegistryComponent> colcomm, ProtoId<JobPrototype> jobId, out int? slots)
+        => colcomm.Comp.CurrentSlots.TryGetValue(jobId, out slots);
+
+    public bool TryAdjustJobSlot(Entity<ColcommJobRegistryComponent> colcomm, ProtoId<JobPrototype> jobId, int amount, bool clamp = false)
+    {
+        if (!colcomm.Comp.CurrentSlots.TryGetValue(jobId, out var current))
+            return false;
+
+        if (current == null)
+            return true; // Unlimited; no adjustment needed
+
+        var newVal = current.Value + amount;
+        if (newVal < 0 && !clamp)
+            return false;
+
+        colcomm.Comp.CurrentSlots[jobId] = Math.Max(newVal, 0);
+        Dirty(colcomm);
+        return true;
+    }
+
+    // Sets the available slot count.
+    public bool TrySetJobSlot(Entity<ColcommJobRegistryComponent> colcomm, ProtoId<JobPrototype> jobId, int amount, bool createSlot = false)
+    {
+        if (!colcomm.Comp.CurrentSlots.ContainsKey(jobId))
+        {
+            if (!createSlot)
+                return false;
+        }
+
+        colcomm.Comp.CurrentSlots[jobId] = amount;
+        Dirty(colcomm);
+        return true;
+    }
+
+    // Sets the mid-round max for the given job.
+    public bool TrySetJobMidRoundMax(Entity<ColcommJobRegistryComponent> colcomm, ProtoId<JobPrototype> jobId, int amount, bool createSlot = false)
+    {
+        if (!colcomm.Comp.MidRoundMaxSlots.ContainsKey(jobId))
+        {
+            if (!createSlot)
+                return false;
+        }
+
+        colcomm.Comp.MidRoundMaxSlots[jobId] = amount;
+        Dirty(colcomm);
+        return true;
+    }
+
+    public bool IsPlayerJobTracked(Entity<ColcommJobRegistryComponent> colcomm, NetUserId userId, ProtoId<JobPrototype> jobId)
+        => colcomm.Comp.PlayerJobs.TryGetValue(userId, out var jobs) && jobs.Contains(jobId);
+
+    public bool TryTrackPlayerJob(Entity<ColcommJobRegistryComponent> colcomm, NetUserId userId, ProtoId<JobPrototype> jobId)
+    {
+        colcomm.Comp.PlayerJobs.TryAdd(userId, new HashSet<ProtoId<JobPrototype>>());
+        colcomm.Comp.PlayerJobs[userId].Add(jobId);
+        Dirty(colcomm);
+        return true;
+    }
+
+    public bool TryUntrackPlayerJob(Entity<ColcommJobRegistryComponent> colcomm, NetUserId userId, ProtoId<JobPrototype> jobId)
+    {
+        if (!colcomm.Comp.PlayerJobs.TryGetValue(userId, out var jobs))
+            return false;
+
+        jobs.Remove(jobId);
+        if (jobs.Count == 0)
+            colcomm.Comp.PlayerJobs.Remove(userId);
+
+        Dirty(colcomm);
+        return true;
+    }
+}
+
+// Raised after the ColComm registry has been reset to defaults at the start of a new round.
+public sealed class ColcommRegistryRoundStartEvent : EntityEventArgs
+{
+    public Entity<ColcommJobRegistryComponent> Colcomm;
+}

--- a/Content.Server/_HL/RoundPersistence/Systems/RoundPersistenceSystem.cs
+++ b/Content.Server/_HL/RoundPersistence/Systems/RoundPersistenceSystem.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using System.Threading;
 using Content.Server.Administration.Systems;
 using Content.Server.CharacterInfo; // For CharacterInfo updates
-using Content.Server.CrewManifest;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Server.Mind; // For MindSystem
@@ -63,7 +62,6 @@ public sealed class RoundPersistenceSystem : EntitySystem
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private StationRecordsSystem _stationRecords = default!;
-    [Dependency] private CrewManifestSystem _crewManifest = default!;
     [Dependency] private ShuttleRecordsSystem _shuttleRecords = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
@@ -304,8 +302,6 @@ public sealed class RoundPersistenceSystem : EntitySystem
             return;
 
         //_sawmill.Info("Round started, will restore data when stations are created");
-
-
     }
 
     /// <summary>

--- a/Content.Server/_HL/StationEvents/Events/DynamicJobAllocationRule.cs
+++ b/Content.Server/_HL/StationEvents/Events/DynamicJobAllocationRule.cs
@@ -1,12 +1,13 @@
 using System;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Server._NF.Roles.Systems;
 using Content.Server.GameTicking;
 using Content.Server.Station.Systems; // HardLight
-using Content.Server.Station.Components;
 using Content.Server.StationEvents.Components;
 using Content.Shared._NF.Roles.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Mind; // HardLight
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles; // HardLight
 using JetBrains.Annotations;
@@ -21,7 +22,7 @@ namespace Content.Server.StationEvents.Events;
 public sealed class DynamicJobAllocationRule : StationEventSystem<DynamicJobAllocationRuleComponent>
 {
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
-    [Dependency] private readonly StationSystem _stationSystem = default!; // HardLight
+    [Dependency] private readonly ColcommJobSystem _colcommJobs = default!; // HardLight
     [Dependency] private readonly IPlayerManager _playerManager = default!;
 
     // HardLight: Legacy job id used before Mercenary/Freelancer naming cleanup.
@@ -36,9 +37,14 @@ public sealed class DynamicJobAllocationRule : StationEventSystem<DynamicJobAllo
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
         SubscribeLocalEvent<PlayerJoinedLobbyEvent>(OnPlayerJoinedLobby);
         SubscribeLocalEvent<JobTrackingStateChangedEvent>(OnJobTrackingStateChanged);
+        SubscribeLocalEvent<JobTrackingComponent, ComponentShutdown>(OnTrackedJobShutdown); // HardLight
+        SubscribeLocalEvent<VisitingMindComponent, ComponentInit>(OnVisitingMindAdded); // HardLight
+        SubscribeLocalEvent<VisitingMindComponent, ComponentShutdown>(OnVisitingMindRemoved); // HardLight
         SubscribeLocalEvent<MindAddedMessage>(OnMindAddedGlobal, after: new[] { typeof(JobTrackingSystem) });
         SubscribeLocalEvent<MindRemovedMessage>(OnMindRemovedGlobal, after: new[] { typeof(JobTrackingSystem) });
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+
+        SubscribeLocalEvent<StationInitializedEvent>(OnStationInitialized); // HardLight
     }
 
     public override void Shutdown()
@@ -77,40 +83,20 @@ public sealed class DynamicJobAllocationRule : StationEventSystem<DynamicJobAllo
         }
     }
 
-    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
-    {
-        QueueRecalculation();
-    }
+    // HardLight start
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev) => QueueRecalculation();
+    private void OnJobTrackingStateChanged(JobTrackingStateChangedEvent ev) => QueueRecalculation();
+    private void OnTrackedJobShutdown(EntityUid uid, JobTrackingComponent component, ref ComponentShutdown args) => QueueRecalculation();
+    private void OnVisitingMindAdded(EntityUid uid, VisitingMindComponent component, ref ComponentInit args) => QueueRecalculation();
+    private void OnVisitingMindRemoved(EntityUid uid, VisitingMindComponent component, ref ComponentShutdown args) => QueueRecalculation();
+    private void OnPlayerJoinedLobby(PlayerJoinedLobbyEvent ev) => QueueRecalculation();
+    private void OnMindAddedGlobal(MindAddedMessage ev) => QueueRecalculation();
+    private void OnMindRemovedGlobal(MindRemovedMessage ev) => QueueRecalculation();
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e) => QueueRecalculation();
+    private void OnStationInitialized(StationInitializedEvent ev) => QueueRecalculation();
 
-    private void OnJobTrackingStateChanged(JobTrackingStateChangedEvent ev)
-    {
-        QueueRecalculation();
-    }
-
-    private void OnPlayerJoinedLobby(PlayerJoinedLobbyEvent ev)
-    {
-        QueueRecalculation();
-    }
-
-    private void OnMindAddedGlobal(MindAddedMessage ev)
-    {
-        QueueRecalculation();
-    }
-
-    private void OnMindRemovedGlobal(MindRemovedMessage ev)
-    {
-        QueueRecalculation();
-    }
-
-    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
-    {
-        QueueRecalculation();
-    }
-
-    private void QueueRecalculation()
-    {
-        _recalculationQueued = true;
-    }
+    private void QueueRecalculation() => _recalculationQueued = true;
+    // HardLight end
 
     private void UpdateActiveRules()
     {
@@ -123,79 +109,56 @@ public sealed class DynamicJobAllocationRule : StationEventSystem<DynamicJobAllo
 
     private void AdjustJobSlots(EntityUid uid, DynamicJobAllocationRuleComponent component)
     {
-        var stations = new Dictionary<EntityUid, (int staffedNonMercenary, int filledMercenary)>();
-        var staffedEntities = new HashSet<EntityUid>();
-
-        var stationQuery = EntityQueryEnumerator<StationJobsComponent>();
-        while (stationQuery.MoveNext(out var stationUid, out _))
-        {
-            stations[stationUid] = (0, 0);
-        }
-
-        if (stations.Count == 0)
+        // HardLight: ColComm registry must exist before we can update slots.
+        if (!_colcommJobs.TryGetColcommRegistry(out var colcomm))
             return;
 
-        foreach (var session in _playerManager.Sessions)
+        // HardLight start
+        /// <summary>
+        /// Count non-Mercenary crew and filled Mercenary slots across the whole server.
+        /// This is mind-based rather than attached-entity based so admins who aghost
+        /// still count as occupying their role until their mind actually leaves the body.
+        /// Using ColComm's configured job list as the filter ensures ship/vessel jobs
+        /// such as Contractor and Pilot do not inflate the Mercenary cap.
+        /// </summary>
+        var totalNonMercenary = 0;
+        var totalFilledMercenary = 0;
+
+        var jobsQuery = EntityQueryEnumerator<JobTrackingComponent, MindContainerComponent>();
+        while (jobsQuery.MoveNext(out _, out var jobTracking, out var mindContainer))
         {
-            if (session.AttachedEntity is not { } attached)
+            if (!jobTracking.Active
+                || jobTracking.Job is not { } job)
                 continue;
 
-            if (session.Status != SessionStatus.InGame)
+            if (!mindContainer.HasMind
+                || !TryComp<MindComponent>(mindContainer.Mind, out var mind)
+                || mind.UserId is not { } userId
+                || !_playerManager.TryGetSessionById(userId, out var session)
+                || session.Status != SessionStatus.InGame)
                 continue;
 
-            staffedEntities.Add(attached);
+            if (IsMercenaryJob(job, component))
+                totalFilledMercenary++;
+            else if (_colcommJobs.IsConfiguredJob(colcomm, job))
+                totalNonMercenary++;
         }
 
-        var jobsQuery = EntityQueryEnumerator<JobTrackingComponent, TransformComponent>(); // HardLight: Added TransformComponent
-        while (jobsQuery.MoveNext(out var jobTrackedEntity, out var jobTracking, out var xform)) // HardLight: Added out var xform
+        var desiredTotal = Math.Min(totalNonMercenary, component.MercenaryCap);
+        var availableSlots = Math.Max(0, desiredTotal - totalFilledMercenary);
+
+        // Update ColComm registry (authoritative for tracking).
+        _colcommJobs.TrySetJobMidRoundMax(colcomm, component.MercenaryJob, desiredTotal, createSlot: true);
+        _colcommJobs.TrySetJobSlot(colcomm, component.MercenaryJob, availableSlots, createSlot: true);
+
+        // Mirror to every physical station's StationJobsComponent for lobby display.
+        var stationQuery = EntityQueryEnumerator<Station.Components.StationJobsComponent>();
+        while (stationQuery.MoveNext(out var stationUid, out _))
+        // HardLight end
         {
-            if (!staffedEntities.Contains(jobTrackedEntity)
-                || !jobTracking.Active // HardLight
-                || jobTracking.Job is not { } job) // HardLight
-                continue;
-
-            var stationUid = ResolveTrackedEntityStation(jobTrackedEntity, jobTracking, xform, stations); // HardLight
-            if (stationUid is not { } resolvedStation // HardLight
-                || !stations.TryGetValue(resolvedStation, out var counts))
-                continue;
-
-            if (IsMercenaryJob(job, component)) // HardLight
-                counts.filledMercenary++;
-            else
-                counts.staffedNonMercenary++;
-
-            stations[resolvedStation] = counts; // HardLight: jobTracking.SpawnStation<resolvedStation
-        }
-
-        foreach (var (stationUid, counts) in stations)
-        {
-            var desiredTotalSlots = Math.Min(counts.staffedNonMercenary, component.MercenaryCap);
-            var availableSlots = Math.Max(0, desiredTotalSlots - counts.filledMercenary);
-
-            _stationJobs.TrySetJobMidRoundMax(stationUid, component.MercenaryJob, desiredTotalSlots);
-
+            _stationJobs.TrySetJobMidRoundMax(stationUid, component.MercenaryJob, desiredTotal);
             _stationJobs.TrySetJobSlot(stationUid, component.MercenaryJob, availableSlots);
         }
-    }
-
-    // HardLight: Handle stale SpawnStation references after round transitions by resolving current station ownership.
-    private EntityUid? ResolveTrackedEntityStation(
-        EntityUid trackedEntity,
-        JobTrackingComponent jobTracking,
-        TransformComponent xform,
-        Dictionary<EntityUid, (int staffedNonMercenary, int filledMercenary)> stations)
-    {
-        // Fast path: if spawn station is still valid for this round, keep using it.
-        if (stations.ContainsKey(jobTracking.SpawnStation))
-            return jobTracking.SpawnStation;
-
-        // Round transitions can invalidate stored spawn station UIDs; resolve the current owner.
-        var owningStation = _stationSystem.GetOwningStation(trackedEntity, xform);
-        if (owningStation is not { } stationUid || !stations.ContainsKey(stationUid))
-            return null;
-
-        // Use resolved station for this calculation pass without mutating shared tracking state.
-        return stationUid;
     }
 
     // HardLight: Count both current and legacy freelancer ids as mercenary-equivalent for slot accounting.

--- a/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/InterviewHologramSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking;
 using Content.Server.PDA.Ringer;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Systems;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Shared._NF.Roles.Components;
 using Content.Shared._NF.Roles.Events;
 using Content.Shared.Chat;
@@ -44,6 +45,7 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
     [Dependency] private StationJobsSystem _stationJobs = default!;
     [Dependency] private StationSpawningSystem _stationSpawning = default!;
     [Dependency] private StationSystem _station = default!;
+    [Dependency] private ColcommJobSystem _colcommJobs = default!; // HardLight
 
     public override void Initialize()
     {
@@ -116,7 +118,14 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
         if (TryComp<JobTrackingComponent>(ent, out var jobTracking))
         {
             if (jobTracking.Job != null)
-                _stationJobs.TryAdjustJobSlot(jobTracking.SpawnStation, jobTracking.Job, 1);
+            // HardLight start
+            {
+                _stationJobs.TryAdjustJobSlot(jobTracking.SpawnStation, jobTracking.Job.Value, 1);
+                _colcommJobs.TryGetColcommRegistry(out var colcomm);
+                if (colcomm != default)
+                    _colcommJobs.TryAdjustJobSlot(colcomm, jobTracking.Job.Value, 1);
+            }
+            // HardLight end
             RemComp<JobTrackingComponent>(ent);
         }
 
@@ -139,7 +148,7 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
             ApplyAppearanceForSession(ent, session);
         }
 
-        // Notify all relevant captains if they have their PDA that someone is applying for a job. 
+        // Notify all relevant captains if they have their PDA that someone is applying for a job.
         if (!ent.Comp.NotificationsSent)
         {
             string jobTitle;
@@ -311,7 +320,14 @@ public sealed class InterviewHologramSystem : SharedInterviewHologramSystem
         if (TryComp<JobTrackingComponent>(ent, out var jobTracking))
         {
             if (jobTracking.Job != null && reopenSlot)
-                _stationJobs.TryAdjustJobSlot(jobTracking.SpawnStation, jobTracking.Job, 1);
+            // HardLight start
+            {
+                _stationJobs.TryAdjustJobSlot(jobTracking.SpawnStation, jobTracking.Job.Value, 1);
+                _colcommJobs.TryGetColcommRegistry(out var colcomm);
+                if (colcomm != default)
+                    _colcommJobs.TryAdjustJobSlot(colcomm, jobTracking.Job.Value, 1);
+            }
+            // HardLight end
             RemComp<JobTrackingComponent>(ent);
         }
 

--- a/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._NF.CryoSleep;
+using Content.Server._HL.ColComm; // HardLight
 using Content.Server.Afk;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
@@ -9,19 +10,26 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
+using Robust.Shared.Network; // HardLight
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._NF.Roles.Systems;
 
+/// HardLight start: Rewritten
 /// <summary>
-/// This handles job tracking for station jobs that should be reopened on cryo.
+/// Handles job slot open/close lifecycle for tracked station jobs.
+/// All slot operations are routed through the persistent
+/// <see cref="ColcommJobRegistryComponent"/> on the ColComm grid entity,
+/// which survives round transitions and avoids stale EntityUid issues.
 /// </summary>
+// HardLight end
 public sealed class JobTrackingSystem : SharedJobTrackingSystem
 {
     [Dependency] private readonly IAfkManager _afk = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
+    [Dependency] private readonly ColcommJobSystem _colcommJobs = default!; // HardLight
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -31,41 +39,52 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         SubscribeLocalEvent<JobTrackingComponent, CryosleepBeforeMindRemovedEvent>(OnJobBeforeCryoEntered);
         SubscribeLocalEvent<JobTrackingComponent, MindAddedMessage>(OnJobMindAdded);
         SubscribeLocalEvent<JobTrackingComponent, MindRemovedMessage>(OnJobMindRemoved);
+        SubscribeLocalEvent<ColcommRegistryRoundStartEvent>(OnColcommRegistryRoundStart); // HardLight
     }
 
-    // If, through admin jiggery pokery, the player returns (or the mob is controlled), we should close the slot if it's opened.
+    /// <summary>
+    /// HardLight: After the ColComm registry resets to defaults, deduct slots for all crew
+    /// that persisted from the previous round (Active = true in their JobTrackingComponent).
+    /// </summary>
+    private void OnColcommRegistryRoundStart(ColcommRegistryRoundStartEvent ev)
+    {
+        var activeCounts = new Dictionary<ProtoId<JobPrototype>, int>();
+
+        var jobQuery = AllEntityQuery<JobTrackingComponent>();
+        while (jobQuery.MoveNext(out _, out var job))
+        {
+            if (!job.Active || job.Job is not { } jobId)
+                continue;
+
+            activeCounts.TryGetValue(jobId, out var existing);
+            activeCounts[jobId] = existing + 1;
+        }
+
+        if (activeCounts.Count > 0)
+            _colcommJobs.DeductActiveRoles(ev.Colcomm, activeCounts);
+    }
+
+    // HardLight: If a player returns to their body (or an admin forces a mind in), consume a
+    // ColComm slot unless we already track them.
     private void OnJobMindAdded(Entity<JobTrackingComponent> ent, ref MindAddedMessage ev)
     {
-        // HardLight: If the job is null, don't do anything.
+        // If the job is null, don't do anything.
         if (ent.Comp.Job is not { } job)
             return;
 
-        // HardLight: If the job is already active, don't do anything.
-        if (ent.Comp.Active)
+        if (!ent.Comp.Active)
+        {
+            ent.Comp.Active = true;
+            RaiseLocalEvent(new JobTrackingStateChangedEvent());
+        }
+
+        if (!JobShouldBeReopened(job))
             return;
 
-        ent.Comp.Active = true;
-        RaiseLocalEvent(new JobTrackingStateChangedEvent()); // HardLight
-
-        if (!JobShouldBeReopened(ent.Comp.Job.Value))
+        if (!_player.TryGetSessionByEntity(ent, out var session))
             return;
 
-        try
-        {
-            if (!TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs)
-                || !_stationJobs.TryGetJobSlot(ent.Comp.SpawnStation, job, out var slots)
-                || slots == null)
-                return;
-
-            // The character is back, readjust their job slot if you can.
-            _stationJobs.TryAdjustJobSlot(ent.Comp.SpawnStation, job, -1);
-        }
-        catch (ArgumentException)
-        {
-        }
-        catch (KeyNotFoundException)
-        {
-        }
+        CloseJob(ent, session.UserId);
     }
 
     private void OnJobMindRemoved(Entity<JobTrackingComponent> ent, ref MindRemovedMessage ev)
@@ -73,7 +92,7 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         if (ent.Comp.Job == null || !ent.Comp.Active || !JobShouldBeReopened(ent.Comp.Job.Value))
             return;
 
-        OpenJob(ent);
+        OpenJob(ent, ev.Mind.Comp.UserId); // HardLight: Added ev.Mind.Comp.UserId
     }
 
     private void OnJobBeforeCryoEntered(Entity<JobTrackingComponent> ent, ref CryosleepBeforeMindRemovedEvent ev)
@@ -81,61 +100,112 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         if (ent.Comp.Job == null || !ent.Comp.Active || !JobShouldBeReopened(ent.Comp.Job.Value))
             return;
 
-        OpenJob(ent);
+        OpenJob(ent, ev.User); // HardLight: Added ev.User
         ev.DeleteEntity = true;
     }
 
-    public void OpenJob(Entity<JobTrackingComponent> ent)
+    public void OpenJob(Entity<JobTrackingComponent> ent, NetUserId? userId = null) // HardLight: Added NetUserId? userId = null
     {
         if (ent.Comp.Job is not { } job)
             return;
 
-        if (!TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs))
+        if (!_colcommJobs.TryGetColcommRegistry(out var colcomm)) // HardLight: TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs)<_colcommJobs.TryGetColcommRegistry(out var colcomm)
             return;
 
         ent.Comp.Active = false;
         RaiseLocalEvent(new JobTrackingStateChangedEvent()); // HardLight
 
-        try
-        {
-            if (!_stationJobs.TryGetJobSlot(ent.Comp.SpawnStation, job, out var slots)
-                || slots == null)
-                return;
+        if (!_colcommJobs.TryGetJobSlot(colcomm, job, out var slots) || slots == null) // HardLight
+            return;
 
-            // Get number of open job slots that are present (not on the cryo map [or on expedition]).
-            var occupiedJobs = GetNumberOfActiveRoles(job, includeAfk: true, exclude: ent);
+        // HardLight start
+        // Only reopen if total occupancy (others still active) + current slots
+        // hasn't already reached the configured cap.
+        var occupiedJobs = GetNumberOfActiveRoles(job, includeAfk: true, exclude: ent, includeOutsideDefaultMap: true);
+        var midRoundMax = colcomm.Comp.MidRoundMaxSlots.GetValueOrDefault(job, 0);
 
-            if (slots + occupiedJobs >= stationJobs.SetupAvailableJobs[job][1])
-                return;
+        if (slots + occupiedJobs >= midRoundMax)
+            return;
 
-            _stationJobs.TryAdjustJobSlot(ent.Comp.SpawnStation, job, 1);
-        }
-        catch (ArgumentException)
+        _colcommJobs.TryAdjustJobSlot(colcomm, job, 1);
+
+        // Mirror the slot open to the physical station display (best-effort).
+        if (TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs))
+            _stationJobs.TryAdjustJobSlot(ent.Comp.SpawnStation, job, 1, stationJobs: stationJobs);
+
+        NetUserId? trackedUserId = userId;
+        if (trackedUserId == null && _player.TryGetSessionByEntity(ent, out var session))
+            trackedUserId = session.UserId;
+
+        if (trackedUserId != null)
         {
+            _colcommJobs.TryUntrackPlayerJob(colcomm, trackedUserId.Value, job);
+            if (stationJobs != null)
+                _stationJobs.TryUntrackPlayerJob(ent.Comp.SpawnStation, trackedUserId.Value, job, stationJobs);
         }
-        catch (KeyNotFoundException)
+        // HardqLight end
+    }
+
+    // HardLight: CloseJob consumes a reopened slot and re-tracks the player in ColComm/station job registries.
+    private void CloseJob(Entity<JobTrackingComponent> ent, NetUserId userId)
+    {
+        if (ent.Comp.Job is not { } job)
+            return;
+
+        if (!ent.Comp.Active)
         {
+            ent.Comp.Active = true;
+            RaiseLocalEvent(new JobTrackingStateChangedEvent());
         }
+
+        if (!JobShouldBeReopened(job))
+            return;
+
+        if (!_colcommJobs.TryGetColcommRegistry(out var colcomm))
+            return;
+
+        if (_colcommJobs.IsPlayerJobTracked(colcomm, userId, job))
+            return;
+
+        if (!_colcommJobs.TryGetJobSlot(colcomm, job, out var slots) || slots == null)
+            return;
+
+        if (slots > 0)
+        {
+            _colcommJobs.TryAdjustJobSlot(colcomm, job, -1, clamp: true);
+
+            if (!_stationJobs.IsPlayerJobTracked(ent.Comp.SpawnStation, userId, job)
+                && TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs))
+            {
+                _stationJobs.TryAdjustJobSlot(ent.Comp.SpawnStation, job, -1, clamp: true, stationJobs: stationJobs);
+                _stationJobs.TryTrackPlayerJob(ent.Comp.SpawnStation, userId, job, stationJobs);
+            }
+        }
+
+        _colcommJobs.TryTrackPlayerJob(colcomm, userId, job);
     }
 
     /// <summary>
     /// Returns the number of active players who match the requested Job Prototype Id.
     /// </summary>
-    /// <param name="jobProtoId">PrototypeID for a job to check.</param>
-    /// <param name="includeAfk">If true, includes AFK players in the check.</param>
-    /// <returns>The number of active players with this job.</returns>
-    public int GetNumberOfActiveRoles(ProtoId<JobPrototype> jobProtoId, bool includeAfk = true, EntityUid? exclude = null)
+    // HardLight start
+    public int GetNumberOfActiveRoles(
+        ProtoId<JobPrototype> jobProtoId,
+        bool includeAfk = true,
+        EntityUid? exclude = null,
+        bool includeOutsideDefaultMap = false)
+    // HardLight end
     {
         var activeJobCount = 0;
         var jobQuery = AllEntityQuery<JobTrackingComponent, MindContainerComponent, TransformComponent>();
-        while (jobQuery.MoveNext(out var uid, out var job, out _, out var xform)) // HardLight: out var mindContainer< out _
+        while (jobQuery.MoveNext(out var uid, out var job, out _, out var xform)) // HardLight: out var mindContainer<out _
         {
             if (exclude == uid)
                 continue;
 
             if (!job.Active
                 || job.Job != jobProtoId
-                || xform.MapID != _gameTicker.DefaultMap) // Skip if they're in cryo or on expedition
+                || (!includeOutsideDefaultMap && xform.MapID != _gameTicker.DefaultMap)) // Skip if they're in cryo or on expedition, // HardLight: Added !includeOutsideDefaultMap
                 continue;
 
             if (_player.TryGetSessionByEntity(uid, out var session))

--- a/Content.Server/_NF/SectorServices/SectorServiceSystem.cs
+++ b/Content.Server/_NF/SectorServices/SectorServiceSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared._NF.SectorServices.Prototypes;
-using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 
@@ -25,7 +24,6 @@ public sealed class SectorServiceSystem : EntitySystem
 
         SubscribeLocalEvent<StationSectorServiceHostComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<StationSectorServiceHostComponent, ComponentRemove>(OnComponentRemove);
-        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnCleanup);
     }
 
     private void OnComponentInit(EntityUid uid, StationSectorServiceHostComponent component, ComponentInit args)
@@ -42,27 +40,14 @@ public sealed class SectorServiceSystem : EntitySystem
                 _entityManager.AddComponents(_entity, servicePrototype.Components, false); // removeExisting false - do not override existing components.
             }
         }
+
+        // HardLight: Always point the current host at the active service entity.
+        component.SectorUid = _entity;
     }
 
     private void OnComponentRemove(EntityUid uid, StationSectorServiceHostComponent component, ComponentRemove args)
     {
-        Log.Debug($"ComponentRemove called! Entity: {_entity}");
-        DeleteServiceEntity();
-    }
-
-    public void OnCleanup(RoundRestartCleanupEvent _)
-    {
-        Log.Debug($"RoundRestartCleanup called! Entity: {_entity}");
-        DeleteServiceEntity();
-    }
-
-    private void DeleteServiceEntity()
-    {
-        if (EntityManager.EntityExists(_entity) && !Terminating(_entity))
-        {
-            QueueDel(_entity);
-        }
-        _entity = EntityUid.Invalid;
+        Log.Debug($"ComponentRemove called for host {uid}. Keeping sector service entity {_entity} alive."); // HardLight: Editted
     }
 
     public EntityUid GetServiceEntity()

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -19,9 +19,8 @@
         stationDescription: 'hardlight-lobby-hardlight-description'
         lobbySortOrder: 1
       - type: StationJobs
-        availableJobs: # 60 jobs total w/o latejoins & interns, 77 jobs total w/ latejoins & interns
-          #command (7)
-          StationTrafficController: [ 1, 1 ]
+        availableJobs: # HardLight: Reordered + additions added
+          # Command (8)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,59 +28,58 @@
           ChiefEngineer: [ 1, 1 ]
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
-          #service (14)
-          Bartender: [ 2, 2 ]
-          Botanist: [ 3, 3 ]
-          Chef: [ 2, 2 ]
-          Janitor: [ 2, 2 ]
-          Chaplain: [ 1, 1 ]
-          Librarian: [ 1, 1 ]
-          ServiceWorker: [ 2, 2 ]
-          Reporter: [ 1, 1 ]
-          #engineering (5 - 7)
-          AtmosphericTechnician: [ 3, 3 ]
-          StationEngineer: [ 2, 4 ]
-          TechnicalAssistant: [ 2, 2 ] #intern, not counted
-          #medical (10 - 12)
-          Chemist: [ 2, 2 ]
-          MedicalDoctor: [ 4, 6 ]
-          Paramedic: [ 2, 2 ]
-          MedicalIntern: [ 2, 2 ] #intern, not counted
-          Psychologist: [ 1, 1 ]
-          Geneticist: [ 1, 1 ]
-          #science (4 - 6)
-          Scientist: [ 4, 6 ]
-          ResearchAssistant: [ 2, 2 ] #intern, not counted
-          #security (8 - 10)
-          Warden: [ 1, 1 ]
-          SecurityOfficer: [ 4, 6 ]
-          Detective: [ 1, 1 ]
-          SecurityCadet: [ 2, 2 ] #intern, not counted
-          Lawyer: [ 2, 2 ]
-          #supply (6 - 7)
-          SalvageSpecialist: [ 3, 3 ]
-          CargoTechnician: [ 3, 4 ]
-          #civilian (3+)
-          Passenger: [ -1, -1 ] #infinite, not counted
-          Clown: [ 1, 1 ]
-          Mime: [ 1, 1 ]
-          Musician: [ 1, 1 ]
-          #silicon (4)
+          StationTrafficController: [ 1, 1 ]
+          # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]
-          #frontier
-          #Contractor: [ -1, -1 ]
-          #Pilot: [ 5, 5 ]
-          Mercenary: [ 0, 40 ]
-          MedicalQuadBorg: [ 3, 3 ]
+          # Service (11)
+          Chef: [ 2, 2 ]
+          Botanist: [ 2, 3 ]
+          Bartender: [ 2, 2 ]
+          Janitor: [ 3, 4 ]
+          ServiceWorker: [ 4, 4 ]
+          Chaplain: [ 1, 1 ]
+          Reporter: [ 2, 2 ]
+          Librarian: [ 1, 1 ]
+          Valet: [ 1, 2 ]
+          Boxer: [ 2, 2 ]
           ServiceQuadBorg: [ 3, 3 ]
-          SalvageQuadBorg: [ 3, 3 ]
+          # Security (6)
+          Warden: [ 1, 1 ]
+          Detective: [ 2, 2 ]
+          SecurityOfficer: [ 6, 6 ]
+          SecurityCadet: [ 3, 3 ]
+          Lawyer: [ 1, 1 ]
           SecurityQuadBorg: [ 3, 3 ]
+          # Medical (7)
+          Paramedic: [ 2, 3 ]
+          Geneticist: [ 1, 2 ]
+          Chemist: [ 2, 3 ]
+          MedicalDoctor: [ 6, 6 ]
+          MedicalIntern: [ 3, 3 ]
+          Psychologist: [ 1, 1 ]
+          MedicalQuadBorg: [ 3, 3 ]
+          # Engineering (4)
+          AtmosphericTechnician: [ 3, 3 ]
+          StationEngineer: [ 6, 6 ]
+          TechnicalAssistant: [ 3, 3 ]
           EngineeringQuadBorg: [ 3, 3 ]
-          Valet: [ 1, 1 ]
-          MailCarrier: [ 1, 1 ]
-          Prisoner: [ 3, 3 ]
+          # Science (3)
           ForensicMantis: [ 1, 1 ]
+          Scientist: [ 4, 4 ]
+          ResearchAssistant: [ 3, 3 ]
+          # Supply (4)
+          SalvageSpecialist: [ 3, 3 ]
+          CargoTechnician: [ 4, 4 ]
+          MailCarrier: [ 2, 2 ]
+          SalvageQuadBorg: [ 3, 3 ]
+          # Civilian (6)
+          Mercenary: [ 0, 40 ]
+          Passenger: [ -1, -1 ]
+          Prisoner: [ 3, 3 ]
+          Clown: [ 2, 2 ]
+          Mime: [ 2, 2 ]
+          Musician: [ 2, 2 ]
       - type: StationDeadDrop
         maxDeadDrops: 6 # small station
       - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -16,9 +16,8 @@
         #- type: StationEmergencyShuttle
         #  emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
         - type: StationJobs
-          availableJobs: # 60 jobs total w/o latejoins & interns, 77 jobs total w/ latejoins & interns
-            #command (7)
-            StationTrafficController: [ 1, 1 ]
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -26,54 +25,55 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (13 - 14)
-            Bartender: [ 1, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering (7)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (6)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ] #intern, not counted
-            #security (10)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #supply (6)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 3, 3 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
             StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -15,9 +15,8 @@
         #- type: StationEmergencyShuttle
         #  emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
         - type: StationJobs
-          availableJobs: # 63 jobs total w/o latejoins & interns, 82 jobs total w/ latejoins & interns
-            #Command (7)
-            StationTrafficController: [ 1, 1 ]
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -25,58 +24,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #Service (14)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #Engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, exclude from dept count
-            #Medical (8)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ] #intern, exclude from dept count
-            Psychologist: [ 1, 1 ]
-            Geneticist: [ 1, 1 ]
-            #Science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ] #intern, exclude from dept count
-            #Security (9 - 11)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 7 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 4 ] #intern, exclude from dept count
-            Lawyer: [ 2, 2 ]
-            #Supply (6)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 3, 3 ]
-            #Civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #Silicon (3)
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
             StationAi: [ 1, 1 ]
-            Borg: [ 2, 3 ]
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -18,68 +18,67 @@
           stationDescription: 'hardlight-lobby-hardlight-description'
           lobbySortOrder: 1
         - type: StationJobs # 74 jobs total w/o latejoins & interns, 93 jobs total w/ latejoins & interns
-          availableJobs:
-            #command (7)
-            StationTrafficController: [ 1, 1 ]
-            Captain: [ 1, 1 ]
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
+            StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (18 - 19)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 3, 3 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            Reporter: [ 1, 2 ]
-            Boxer: [2, 2]
-            #engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (10)
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ] #intern, not counted
-            #security (12)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #supply (7)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (4)
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -19,8 +19,8 @@
           stationDescription: 'hardlight-lobby-hardlight-description'
           lobbySortOrder: 1
         - type: StationJobs
-          availableJobs: # 56 jobs total w/o latejoins & interns, 64 jobs total w/ latejoins & interns
-            #command (7)
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -28,60 +28,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (16)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            Boxer: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering (6)
-            StationEngineer: [ 4, 4 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (7 - 9)
-            MedicalDoctor: [ 3, 4 ]
-            Chemist: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            Paramedic: [ 1, 2 ]
-            Psychologist: [ 1, 1 ]
-            Geneticist: [ 1, 2 ]
-            #science (3)
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 1, 1 ] #intern, not counted
-            #security (7)
-            SecurityOfficer: [ 4, 4 ]
-            Warden: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ] #intern, not counted
-            Detective: [ 1, 1 ]
-            #supply (5)
-            CargoTechnician: [ 3, 3 ]
-            SalvageSpecialist: [ 2, 2 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            # silicon (3)
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
             StationAi: [ 1, 1 ]
-            Borg: [ -1, -1 ]
-            # frontier
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -18,8 +18,8 @@
 #        - type: StationCargoShuttle
 #          path: /Maps/Shuttles/cargo_elkridge.yml
         - type: StationJobs
-          availableJobs: # 46 jobs total w/o latejoins & interns, 61 jobs total w/ latejoins & interns
-            #command (7)
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -27,58 +27,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (9 - 11)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            #engineering (5 - 6)
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 4 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (6 - 7)
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 3 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            Paramedic: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-            #science (3 - 4)
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (6 - 7)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 3, 4 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ] #intern, not counted
-            Lawyer: [ 1, 1 ]
-            #supply (4 - 5)
-            SalvageSpecialist: [ 2, 2 ]
-            CargoTechnician: [ 2, 3 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ -1, -1 ]
-            # hardlight
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
             StationTrafficController: [ 1, 1 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            # Silicon (2)
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium small station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -17,9 +17,8 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_fland.yml
         - type: StationJobs
-          availableJobs: # 81 jobs total w/o latejoins & interns, 101 jobs total w/ latejoins & interns
-            #command (7)
-            StationTrafficController: [ 1, 1 ]
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -27,57 +26,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (17)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
             Chef: [ 2, 2 ]
-            Janitor: [ 4, 4 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
             Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
-            #engineering (9)
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
+            ServiceQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
+            SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 6, 6 ]
-            TechnicalAssistant: [ 4, 4 ] #intern, not counted
-            #medical (11)
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
-            Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ] #intern, not counted
-            Psychologist: [ 1, 1 ]
-            #science (5)
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ] #intern, not counted
-            #security (14)
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 10, 10 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 6, 6 ] #intern, not counted
-            Lawyer: [ 2, 2 ]
-            #supply (9)
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 6, 6 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            #silicon (6)
-            StationAi: [ 1, 1 ]
-            Borg: [ 5, 5 ]
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
-            ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
-            SecurityQuadBorg: [ 3, 3 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # large station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -19,46 +19,65 @@
           stationDescription: 'hardlight-lobby-hardlight-description'
           lobbySortOrder: 1
         - type: StationJobs
-          availableJobs: # 15 jobs total w/o latejoins, 19 jobs total w/ latejoins
-            #command (2)
-            
-            HeadOfSecurity: [ 1, 1 ]
+          availableJobs: # HardLight: Reordered + additions added
+            # Command (8)
             StationCaptain: [ 1, 1 ]
+            HeadOfPersonnel: [ 1, 1 ]
+            HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (4)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 1, 1 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 1, 1 ]
-            #engineering (2 - 3)
-            AtmosphericTechnician: [ 1, 1 ]
-            StationEngineer: [ 1, 2 ]
-            #medical (2 - 3)
-            Chemist: [ 1, 1 ]
-            MedicalDoctor: [ 1, 2 ]
-            Psychologist: [ 1, 1 ]
-            #science (1)
-            Scientist: [ 1, 1 ]
-            #security (1 - 3)
-            SecurityOfficer: [ 1, 3 ]
-            #supply (2)
-            CargoTechnician: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 1 ]
-            #civilian (1+)
-            #Passenger: [ -1, -1 ] #infinite, not counted
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
-            
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
+

--- a/Resources/Prototypes/_HL/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_HL/Entities/Stations/base.yml
@@ -99,6 +99,67 @@
   abstract: true
   components:
     - type: StationColcomm
+      jobRegistryConfig:
+        # Command (8)
+        StationCaptain: [ 1, 1 ]
+        HeadOfPersonnel: [ 1, 1 ]
+        HeadOfSecurity: [ 1, 1 ]
+        ChiefMedicalOfficer: [ 1, 1 ]
+        ChiefEngineer: [ 1, 1 ]
+        ResearchDirector: [ 1, 1 ]
+        Quartermaster: [ 1, 1 ]
+        StationTrafficController: [ 1, 1 ]
+        # Silicon (2)
+        StationAi: [ 1, 1 ]
+        Borg: [ 3, 3 ]
+        # Service (11)
+        Chef: [ 2, 2 ]
+        Botanist: [ 2, 3 ]
+        Bartender: [ 2, 2 ]
+        Janitor: [ 3, 4 ]
+        ServiceWorker: [ 4, 4 ]
+        Chaplain: [ 1, 1 ]
+        Reporter: [ 2, 2 ]
+        Librarian: [ 1, 1 ]
+        Valet: [ 1, 2 ]
+        Boxer: [ 2, 2 ]
+        ServiceQuadBorg: [ 3, 3 ]
+        # Security (6)
+        Warden: [ 1, 1 ]
+        Detective: [ 2, 2 ]
+        SecurityOfficer: [ 6, 6 ]
+        SecurityCadet: [ 3, 3 ]
+        Lawyer: [ 1, 1 ]
+        SecurityQuadBorg: [ 3, 3 ]
+        # Medical (7)
+        Paramedic: [ 2, 3 ]
+        Geneticist: [ 1, 2 ]
+        Chemist: [ 2, 3 ]
+        MedicalDoctor: [ 6, 6 ]
+        MedicalIntern: [ 3, 3 ]
+        Psychologist: [ 1, 1 ]
+        MedicalQuadBorg: [ 3, 3 ]
+        # Engineering (4)
+        AtmosphericTechnician: [ 3, 3 ]
+        StationEngineer: [ 6, 6 ]
+        TechnicalAssistant: [ 3, 3 ]
+        EngineeringQuadBorg: [ 3, 3 ]
+        # Science (3)
+        ForensicMantis: [ 1, 1 ]
+        Scientist: [ 4, 4 ]
+        ResearchAssistant: [ 3, 3 ]
+        # Supply (4)
+        SalvageSpecialist: [ 3, 3 ]
+        CargoTechnician: [ 4, 4 ]
+        MailCarrier: [ 2, 2 ]
+        SalvageQuadBorg: [ 3, 3 ]
+        # Civilian (6)
+        Mercenary: [ 0, 40 ]
+        Passenger: [ -1, -1 ]
+        Prisoner: [ 3, 3 ]
+        Clown: [ 2, 2 ]
+        Mime: [ 2, 2 ]
+        Musician: [ 2, 2 ]
 
 - type: entity
   id: BaseStationEvacuation

--- a/Resources/Prototypes/_HL/Maps/core.yml
+++ b/Resources/Prototypes/_HL/Maps/core.yml
@@ -19,9 +19,8 @@
           stationDescription: 'hardlight-lobby-hardlight-description'
           lobbySortOrder: 1
         - type: StationJobs
-          availableJobs: # 56 jobs total w/o latejoins & interns, 64 jobs total w/ latejoins & interns
-            #command (7)
-            StationTrafficController: [ 1, 1 ]
+          availableJobs:
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -29,59 +28,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (16)
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 1, 1 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
-            Boxer: [ 2, 2 ]
-            Reporter: [ 2, 2 ]
-            #engineering (6)
-            StationEngineer: [ 4, 4 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (6 - 8)
-            MedicalDoctor: [ 3, 4 ]
-            Chemist: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            Paramedic: [ 1, 2 ]
-            Psychologist: [ 1, 1 ]
-            #science (3)
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 1, 1 ] #intern, not counted
-            #security (7)
-            SecurityOfficer: [ 4, 4 ]
-            Warden: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ] #intern, not counted
-            Detective: [ 1, 1 ]
-            #supply (5)
-            CargoTechnician: [ 3, 3 ]
-            SalvageSpecialist: [ 2, 2 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            # silicon (3)
+            StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
             StationAi: [ 1, 1 ]
-            Borg: [ -1, -1 ]
-            # frontier
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
             ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
             SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
             EngineeringQuadBorg: [ 3, 3 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/_HL/Maps/eaglerock.yml
+++ b/Resources/Prototypes/_HL/Maps/eaglerock.yml
@@ -19,8 +19,8 @@
           stationDescription: 'hardlight-lobby-hardlight-description'
           lobbySortOrder: 1
         - type: StationJobs
-          availableJobs: # I'm not fucking counting somebody else do that
-            #command (7)
+          availableJobs:
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
@@ -28,59 +28,58 @@
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service (11)
-            Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Reporter: [ 1, 1 ]
-            #engineering (6)
-            StationEngineer: [ 4, 4 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ] #intern, not counted
-            #medical (6 - 8)
-            MedicalDoctor: [ 3, 4 ]
-            Chemist: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ] #intern, not counted
-            Paramedic: [ 1, 1 ]
-            Geneticist: [ 1, 1 ]
-            #science (4)
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ] #intern, not counted
-            #security (7)
-            SecurityOfficer: [ 4, 4 ]
-            Warden: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ] #intern, not counted
-            Detective: [ 1, 1 ]
-            #supply (5)
-            CargoTechnician: [ 3, 3 ]
-            SalvageSpecialist: [ 2, 2 ]
-            #civilian (3+)
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            # silicon (3)
-            StationAi: [ 1, 1 ]
-            Borg: [ -1, -1 ]
-            # frontier
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Mercenary: [ 0, 40 ]
-            MedicalQuadBorg: [ 3, 3 ]
-            ServiceQuadBorg: [ 3, 3 ]
-            SalvageQuadBorg: [ 3, 3 ]
-            SecurityQuadBorg: [ 3, 3 ]
-            EngineeringQuadBorg: [ 3, 3 ]
             StationTrafficController: [ 1, 1 ]
-            Valet: [ 1, 1 ]
-            MailCarrier: [ 1, 1 ]
-            Prisoner: [ 0, 0 ]
+            # Silicon (2)
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
+            ServiceQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
+            SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
+            EngineeringQuadBorg: [ 3, 3 ]
+            # Science (3)
             ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 6 # small station
         - type: StationDeadDropReporting

--- a/Resources/Prototypes/_HL/Maps/silica.yml
+++ b/Resources/Prototypes/_HL/Maps/silica.yml
@@ -16,68 +16,66 @@
 
         - type: StationJobs
           availableJobs:
-            # 103 jobs, Infinite Contractor slots
-            #service (17)
+            # Command (8)
             StationCaptain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            Reporter: [ 1, 2 ]
-            ServiceWorker: [ 2, 3 ]
-            #engineering (9)
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 4 ]
-            TechnicalAssistant: [ 2, 2 ]
-            #medical (13)
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 2, 2 ]
-            Paramedic: [ 2, 2 ]
-            Geneticist: [ 1, 1 ]
-            Psychologist: [ 1, 1 ]
-            #science (8)
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ]
-            ForensicMantis: [ 1, 1 ]
-            #security (14)
             HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 8 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Lawyer: [ 1, 1 ]
-            #supply (10)
+            ChiefMedicalOfficer: [ 1, 1 ]
+            ChiefEngineer: [ 1, 1 ]
+            ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 3 ]
-            CargoTechnician: [ 3, 4 ]
-            MailCarrier: [ 1, 2 ]
-            #civilian (4)
-#            Assistant: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            #silicon (15)
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 4 ]
-            MedicalQuadBorg: [ 2, 2 ]
-            ServiceQuadBorg: [ 2, 2 ]
-            SalvageQuadBorg: [ 2, 2 ]
-            SecurityQuadBorg: [ 2, 2 ]
-            EngineeringQuadBorg: [ 2, 2 ]
-            # frontier (13)
-            #Contractor: [ -1, -1 ]
-            #Pilot: [ 5, 5 ]
-            Passenger: [ -1, -1 ] #infinite, not counted
-            Mercenary: [ 0, 40 ]
-            Prisoner: [ 1, 2 ]
             StationTrafficController: [ 1, 1 ]
+            # Silicon (2)
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]
+            # Service (11)
+            Chef: [ 2, 2 ]
+            Botanist: [ 2, 3 ]
+            Bartender: [ 2, 2 ]
+            Janitor: [ 3, 4 ]
+            ServiceWorker: [ 4, 4 ]
+            Chaplain: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
+            Valet: [ 1, 2 ]
+            Boxer: [ 2, 2 ]
+            ServiceQuadBorg: [ 3, 3 ]
+            # Security (6)
+            Warden: [ 1, 1 ]
+            Detective: [ 2, 2 ]
+            SecurityOfficer: [ 6, 6 ]
+            SecurityCadet: [ 3, 3 ]
+            Lawyer: [ 1, 1 ]
+            SecurityQuadBorg: [ 3, 3 ]
+            # Medical (7)
+            Paramedic: [ 2, 3 ]
+            Geneticist: [ 1, 2 ]
+            Chemist: [ 2, 3 ]
+            MedicalDoctor: [ 6, 6 ]
+            MedicalIntern: [ 3, 3 ]
+            Psychologist: [ 1, 1 ]
+            MedicalQuadBorg: [ 3, 3 ]
+            # Engineering (4)
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 6, 6 ]
+            TechnicalAssistant: [ 3, 3 ]
+            EngineeringQuadBorg: [ 3, 3 ]
+            # Science (3)
+            ForensicMantis: [ 1, 1 ]
+            Scientist: [ 4, 4 ]
+            ResearchAssistant: [ 3, 3 ]
+            # Supply (4)
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 4, 4 ]
+            MailCarrier: [ 2, 2 ]
+            SalvageQuadBorg: [ 3, 3 ]
+            # Civilian (6)
+            Mercenary: [ 0, 40 ]
+            Passenger: [ -1, -1 ]
+            Prisoner: [ 3, 3 ]
+            Clown: [ 2, 2 ]
+            Mime: [ 2, 2 ]
+            Musician: [ 2, 2 ]
         - type: StationDeadDrop
           maxDeadDrops: 2 # medium station
         - type: StationDeadDropReporting


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
About a day and a half later, I've refactored the method which the server handles job slots and removed it from round-spawned stations. Instead, job slots allocation is now handled by the Colonial Command map itself, meaning it should update correctly where changes occur and persist between rounds in a way it previously couldn't. 

In translation, this means job slots should more accurately reflect the number of staffed positions and, with a bit of dynamic allocation similar to how Freelancers currently work, correctly update when jobs are occupied or released. Meaning all jobs should now repopulate when characters assigned to them no longer occupy said jobs.

For example, if the Captain cryos, gibs, /ghosts, or whatever other method might apply that removes the mind from an entity, then their slot will open back up, allowing another player to take the Captain slot. 

It also means that job slots occupied from the previous round are now considered for the new round, meaning a Captain from the previous round will no longer be met by a second Captain upon reaching the next station.

All jobs now function like this.

Additionally, this should finally fix the issue with Freelancer slots exceed the limits that were placed on them, hopefully meaning we should no longer see rounds where 60+ Freelancers exist when there's only supposed to be 40 at any given time. 

It remains to be seen.

Oh, and I made the station records console function between both the station map and ColComm, so there's that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Should make the game better. We will see.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Should be self explanatory, but spawn in, spawn in a second character through a second instance, verify that taking a normal job opens a Freelancer slot, gib yourself, verify that the slot opens back up, and then end the round, restart the round, and verify from the station records that the job slots from the previous rounds are still occupied in the new round. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Possibly everything. Maybe nothing. Definitely my sanity because this took way too long.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Refactored job slot allocation logic.
- fix: Station jobs should now dynamically allocate additional slots when no longer filled.
- fix: Freelancer slot allocation should no longer exceed the number of filled crew positions, nor should it exceed the cap of 40 that was originally placed on it.
