### PR TITLE
Typo moment

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -48,7 +48,7 @@
 
 - type: entity
   parent: [EncryptionKey, BaseColcommCommandContraband] # Frontier: Added BaseColcommCommandContraband, removed BaseColcommContraband.
-  id: EncryptionKeyColComm # HardLight
+  id: EncryptionKeyColCom # HardLight
   name: Colonial Command encryption key
   categories: [ DoNotMap ] # Frontier
   description: An encryption key used by captain's bosses.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/snacks.yml
@@ -38,7 +38,7 @@
   name: engine fodder
   parent: FoodBakingBase
   id: FoodMothEngineFodder
-  description: A common snack for moth engineers, made of seeds, nuts, chocolate, popcorn, and potato chips	designed to be dense with calories and easy to snack on when an extra boost is needed.
+  description: A common snack for moth engineers, made of seeds, nuts, chocolate, popcorn, and potato chips designed to be dense with calories and easy to snack on when an extra boost is needed.
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/_HL/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_HL/Entities/Structures/Machines/telecomms.yml
@@ -36,7 +36,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyColComm
+      - EncryptionKeyColCom
 
 - type: entity
   parent: TelecomServer

--- a/Resources/hl_migration.yml
+++ b/Resources/hl_migration.yml
@@ -1,2 +1,6 @@
 # 13-04-2026
 BorgModuleFireExtinguisher: BorgModuleJetpack
+
+#16-04-2026
+EncryptionKeyCentCom: EncryptionKeyColCom # Added because if we ever import a map with CentCom keys we should want to update it to a ColCom key.
+EncryptionKeyColComm: EncryptionKeyColCom


### PR DESCRIPTION

## About the PR
Fixes the Mapchecker and a typo in an encryption key ID

## Why / Balance
ID was EncryptionKeyColComm. Test wanted EncryptionKeyColCom. I fix.
Also fixes the mapchecker cause there was a random tab in a sentence???

## Technical details
Removes a second m from the EncryptionKeyColComm id, fixes it in the telecomms, and removes a tab from a sentence that was breaking the map checker, replacing it with a space

## How to test
Look at the test

## Media


## Breaking changes
Should not break anything. In fact, fixes tests.

**Changelog**
:cl: R3v3l4t1on
- fix: Removes a test fail from the PILE
- fix: MapChecker works again after someone broke it.
