### PR TITLE
Hotfix xenoborg sprites

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -13,6 +13,7 @@
       sprite: Mobs/Silicon/Chassis/xeno_engi.rsi
       state: borg
   - type: Sprite
+    sprite: Mobs/Silicon/Chassis/xeno_engi.rsi
     layers:
     - state: borg
     - state: borg_e
@@ -73,6 +74,7 @@
       sprite: Mobs/Silicon/Chassis/xeno_heavy.rsi
       state: borg
   - type: Sprite
+    sprite: Mobs/Silicon/Chassis/xeno_heavy.rsi
     layers:
     - state: borg
     - state: borg_e
@@ -168,6 +170,7 @@
       sprite: Mobs/Silicon/Chassis/xeno_scout.rsi
       state: borg
   - type: Sprite
+    sprite: Mobs/Silicon/Chassis/xeno_scout.rsi
     layers:
       - state: borg
       - state: borg_e
@@ -227,6 +230,7 @@
       sprite: Mobs/Silicon/Chassis/xeno_stealth.rsi
       state: borg
   - type: Sprite
+    sprite: Mobs/Silicon/Chassis/xeno_stealth.rsi
     layers:
       - state: borg
       - state: borg_e


### PR DESCRIPTION

## About the PR
Fixes xenoborgs to you know, actually look distinct.

## Why / Balance
When I ported the subtype switchables, I had to move xenoborgs into distinct folders which also meant I had to change some rsi references around. But uhhh. Whilst I ensured the xenoborg transponders looked all right. I failed to realize I had to _actually override the sprite_ in their sprite component. So I did that.

## Technical details
Overrides the sprite on SpriteComponent in all the xenoborgs to ensure they do in fact have unique sprites.

## How to test
Spawn all 4 xenoborgs.
Take note of them actually looking unique

## Media


## Breaking changes
Nah, fixes things

**Changelog**

:cl: R3v3l4t1on
- fix: Fixed all xenoborgs cosplaying as engineers. Now you can actually tell if you're fighting an engi or a fridge.
