### PR TITLE
add more existing plushies to cuddly critter vend and prize balls

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -42,6 +42,66 @@
     - id: PlushieMoth
     - id: PlushieArachind
     - id: PlushiePenguin
+    - id: NFPlushieSharkMinnow
+    - id: PlushieCuddlyIPC
+    - id: PlushieFluffyVulpkanin
+    - id: PlushieMoff
+    - id: PlushieMoffsician
+    - id: PlushieMoffbar
+    - id: PlushieMoffRandom
+    - id: PlushieVulp
+    - id: PlushieGnome
+    - id: PlushieLoveable
+    - id: PlushieDeer
+    - id: PlushieIpc
+    - id: PlushieGrey
+    - id: PlushieHuman
+    - !type:GroupSelector
+      children:
+      - id: PlushieRedFox
+      - id: PlushiePurpleFox
+      - id: PlushiePinkFox
+      - id: PlushieOrangeFox
+      - id: PlushieMarbleFox
+      - id: PlushieCrimsonFox
+      - id: PlushieCoffeeFox
+      - id: PlushieBlueFox
+      - id: PlushieBlackFox
+    - !type:GroupSelector
+      children:
+      - id: PlushieCorgi
+      - id: PlushieGirlyCorgi
+      - id: PlushieRobotCorgi
+    - !type:GroupSelector
+      children:
+      - id: PlushieCatBlack
+      - id: PlushieCatGrey
+      - id: PlushieCatOrange
+      - id: PlushieCatSiames
+      - id: PlushieCatTabby
+      - id: PlushieCatTuxedo
+      - id: PlushieCatWhite
+      - id: PlushieCatAndroid
+    - id: PlushieAnomalous
+    - id: PlushieAvali
+    - id: PlushieBountyHunter
+    - id: PlushieFDrone
+    - id: PlushieFPraetorian
+    - id: PlushieFRavager
+    - id: PlushieFRouny
+    - id: PlushieGalio
+    - id: PlushieGhost
+    - id: PlushieLizardCultist
+    - id: PlushieLizardDetective
+    - id: PlushieLizardHoS
+    - id: PlushieLizardLotl
+    - id: PlushieLizardMaid
+    - id: PlushieMercenary
+    - id: PlushieNemesis
+    - id: PlushieNightmare
+    - id: PlushieSharkCaptain
+    - id: PlushieSlimeVulp
+    - id: PlushieThrongler
 
 - type: entity
   id: CrateFunPlushie

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
@@ -63,7 +63,6 @@
     PlushieGalio: 3
     PlushieGhost: 3
     PlushieHuman: 3
-    PlushieLizardCCO: 3
     PlushieLizardCultist: 3
     PlushieLizardDetective: 3
     PlushieLizardHoS: 3
@@ -121,5 +120,5 @@
     PlushieRGBee: 3
     BalloonCorgi: 2
     NFPlushieBotanist: 3
-    NFPlushieCmo: 3    
+    NFPlushieCmo: 3
     NFPlushieEngineer: 3

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/cuddlycritter.yml
@@ -25,6 +25,58 @@
     PlushieCarp: 3
     PlushieAtmosian: 3
     PlushieXeno: 3
+    PlushieVulp: 3
+    PlushieGnome: 3
+    PlushieLoveable: 3
+    PlushieDeer: 3
+    PlushieIpc: 3
+    PlushieGrey: 3
+    PlushieRedFox: 3
+    PlushiePurpleFox: 3
+    PlushiePinkFox: 3
+    PlushieOrangeFox: 3
+    PlushieMarbleFox: 3
+    PlushieCrimsonFox: 3
+    PlushieCoffeeFox: 3
+    PlushieBlueFox: 3
+    PlushieBlackFox: 3
+    PlushieCorgi: 3
+    PlushieGirlyCorgi: 3
+    PlushieRobotCorgi: 3
+    PlushieCatBlack: 3
+    PlushieCatGrey: 3
+    PlushieCatOrange: 3
+    PlushieCatSiames: 3
+    PlushieCatTabby: 3
+    PlushieCatTuxedo: 3
+    PlushieCatWhite: 3
+    PlushieArachind: 3
+    PlushieAnomalous: 3
+    PlushieAvali: 3
+    PlushieBountyHunter: 3
+    PlushieCatAndroid: 3
+    PlushieExperiment: 3
+    PlushieFDrone: 3
+    PlushieFPraetorian: 3
+    PlushieFRavager: 3
+    PlushieFRouny: 3
+    PlushieGalio: 3
+    PlushieGhost: 3
+    PlushieHuman: 3
+    PlushieLizardCCO: 3
+    PlushieLizardCultist: 3
+    PlushieLizardDetective: 3
+    PlushieLizardHoS: 3
+    PlushieLizardLotl: 3
+    PlushieLizardMaid: 3
+    PlushieMercenary: 3
+    PlushieMoffRandom: 3
+    PlushieNemesis: 3
+    PlushieNightmare: 3
+    PlushiePenguin: 3
+    PlushieSharkCaptain: 3
+    PlushieSlimeVulp: 3
+    PlushieThrongler: 3
     PlasticBanana: 3
     BeachBall: 3
     Basketball: 3

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/prizeticket.yml
@@ -257,6 +257,90 @@
       - id: PlushieCatWhite
         orGroup: Prize
         prob: 0.80
+      - id: PlushieCatGrey
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieArachind
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieAnomalous
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieAvali
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieBountyHunter
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieCatAndroid
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieExperiment
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieFDrone
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieFPraetorian
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieFRavager
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieFRouny
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieGalio
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieGhost
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieHuman
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardCCO
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardCultist
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardDetective
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardHoS
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardLotl
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieLizardMaid
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieMercenary
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieMoffRandom
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieNemesis
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieNightmare
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushiePenguin
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieSharkCaptain
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieSlimeVulp
+        orGroup: Prize
+        prob: 0.80
+      - id: PlushieThrongler
+        orGroup: Prize
+        prob: 0.80
       - id: PrizeTicket
         prob: 0.20
         orGroup: Prize

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/prizeticket.yml
@@ -299,9 +299,6 @@
       - id: PlushieHuman
         orGroup: Prize
         prob: 0.80
-      - id: PlushieLizardCCO
-        orGroup: Prize
-        prob: 0.80
       - id: PlushieLizardCultist
         orGroup: Prize
         prob: 0.80

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/prize_counter.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/prize_counter.yml
@@ -4,6 +4,7 @@
   - PrizeBallRecipe
   - PlushieHampterRecipe
   - PlushieVulpRecipe
+  - PlushieMothRecipe
   - PlushieBeeRecipe
   - PlushieLizardRecipe
   - PlushieSpaceLizardRecipe


### PR DESCRIPTION

## About the PR
add more existing plushies to cuddly critter vend and prize balls

## Why / Balance
plushies exist but aren't obtainable

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: add more existing plushies to cuddly critter vend and prize balls
