### PR TITLE
Buff cheese + booze-o-mat

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -58,7 +58,6 @@
     ChemistryBottleEthanol: 3
     DrinkBottleOfNothingFull: 1
     DrinkNNNCan: 10 # Coyote
-    DrinkBoykisserEnergy: 10 # Coyote
   emaggedInventory:
     DrinkPoisonWinebottleFull: 2
     DrinkPremiumAbsintheBottleFull: 1 # Frontier

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -12,7 +12,7 @@
     DrinkKegSteel: 2 # Frontier: kegs
     DrinkKegWood: 2 # Frontier: kegs
     DrinkKegPlastic: 2 # Frontier: kegs
-    CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
+    CustomDrinkJug: 4 #to allow for custom drinks in the soda/booze dispensers ## Coyote: 2 -> 4
     DrinkAbsintheBottleFull: 1
     DrinkAnisetteBottleFull: 2 # Floofstation
     DrinkAleBottleFull: 5
@@ -37,12 +37,12 @@
     DrinkMelonLiquorBottleFull: 3
     DrinkPatronBottleFull: 2
     DrinkRumBottleFull: 4
-    DrinkSodaWaterCan: 8
-    DrinkSolDryCan: 8
+    DrinkSodaWaterCan: 10 # Coyote: 8 -> 10 (300u)
+    DrinkSolDryCan: 10 # Coyote: 8 -> 10 (300u)
     DrinkSpaceMountainWindBottleFull: 3
     DrinkSpaceUpBottleFull: 3
     DrinkTequilaBottleFull: 3
-    DrinkTonicWaterCan: 8
+    DrinkTonicWaterCan: 10 # Coyote: 8 -> 10 (300u)
     DrinkVermouthBottleFull: 5
     DrinkVodkaBottleFull: 5
     DrinkWhiskeyBottleFull: 5
@@ -52,9 +52,13 @@
     DrinkBeerCan: 5
     DrinkWineCan: 5
     DrinkDisposableCup: 5 # #imp
+    JugCaramexinin: 1 # Frontier ## Hardlight: Why was this emag only.
+    DrinkRootBeerJug: 2 # Coyote
   contrabandInventory:
     ChemistryBottleEthanol: 3
     DrinkBottleOfNothingFull: 1
+    DrinkNNNCan: 10 # Coyote
+    DrinkBoykisserEnergy: 10 # Coyote
   emaggedInventory:
     DrinkPoisonWinebottleFull: 2
     DrinkPremiumAbsintheBottleFull: 1 # Frontier
@@ -63,4 +67,3 @@
     DrinkPremiumTequilaBottleFull: 1 # Frontier
     DrinkPremiumVodkaBottleFull: 1 # Frontier
     DrinkPremiumWhiskeyBottleFull: 1 # Frontier
-    JugCaramexinin: 1 # Frontier

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -161,7 +161,7 @@
       drink:
         reagents:
         - ReagentId: Milk
-          Quantity: 100
+          Quantity: 120 # Coyote: 100 -> 120u
   - type: Sprite
     sprite: Objects/Consumable/Drinks/milk.rsi
 

--- a/Resources/Prototypes/Recipes/Reactions/food.yml
+++ b/Resources/Prototypes/Recipes/Reactions/food.yml
@@ -5,7 +5,7 @@
   conserveEnergy: false
   reactants:
     Milk:
-      amount: 40
+      amount: 20 # Coyote: Halve the cost.
     Enzyme:
       amount: 5
       catalyst: true


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ports https://github.com/ARF-SS13/coyote-frontier/pull/937 and https://github.com/ARF-SS13/coyote-frontier/pull/1039.

> Adds root beer to the Booze-O-Mat's inventory, as well as NNN and Boykisser Energy to the contraband (MNGR wire) inventory. Also ups most drink cans from 8 to 10 (240u -> 300u, one large jug's worth)

> Gives milk bottles 20u more, and halves the cost of cheese wheel production.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
> Right now you can only get two cheese wheels from an entire carton of milk (or 96 biomass in a biogenerator), which is kind of ridiculous. This PR intends to hopefully ease the burden on chefs needing cheese by letting you get six wheels per carton.

> Makes some previously unobtainable drinks acquireable; slightly improves QoL; and also allows to make drinks using root beer if you run out.

## Technical details
<!-- Summary of code changes for easier review. -->
> `DrinkMilkCarton` reagent quantity 100 -> 120u.
`Curdling` reaction milk cost 40 -> 20u.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
> Spawn in a Booze-O-Mat. Buy root beer and make five hundred floats.
Cut the MNGR wire and get high off Boykisser Energy, or something.

> Spawn in a carton of milk, a bluespace beaker, and a universal enzyme.
Add 5u enzyme, and dump the milk in 20u steps. You should get one wheel per 20u, for a total of six wheels.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
See original PR, copying links is annoying.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- add: Root beer jugs to the Booze-o-Mat.
- tweak: Milk cartons now have 20% more milk per milk.
- tweak: Cheese now costs 20u less milk to make.
- tweak: Increased most canned drink stocks by two.
- tweak: Caramexexin is no longer emag-only. Why it was in the first place, we may never know.
- add: Nikko's Naughty Nectar to the Booze-o-Mat.