### PR TITLE
fixed tail wagging action not loading

### DIFF
--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Actions;
 using Content.Server.Humanoid;
 using Content.Shared._CS.Humanoid;
+using Content.Shared._Shitmed.Humanoid.Events; // Hardlight
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mobs;
@@ -26,6 +27,7 @@ public sealed class WaggingSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<WaggingComponent, ComponentInit>(OnWaggingMapInit); // Coyote: Move to Component Init
+        SubscribeLocalEvent<WaggingComponent, ProfileLoadFinishedEvent>(OnProfileLoadFinished); // Hardlight
         SubscribeLocalEvent<WaggingComponent, ComponentShutdown>(OnWaggingShutdown);
         SubscribeLocalEvent<WaggingComponent, ToggleActionEvent>(OnWaggingToggle);
         SubscribeLocalEvent<WaggingComponent, MobStateChangedEvent>(OnMobStateChanged);
@@ -33,7 +35,18 @@ public sealed class WaggingSystem : EntitySystem
 
     private void OnWaggingMapInit(EntityUid uid, WaggingComponent component, ComponentInit args) // Coyote: Move to Component Init
     {
+        // Hardlight start
+        EnsureWaggingAction(uid, component);
+    }
 
+    private void OnProfileLoadFinished(EntityUid uid, WaggingComponent component, ref ProfileLoadFinishedEvent args)
+    {
+        EnsureWaggingAction(uid, component);
+    }
+
+    private void EnsureWaggingAction(EntityUid uid, WaggingComponent component)
+    {
+        // Hardlight end
         if (!TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
             return;
 
@@ -82,11 +95,13 @@ public sealed class WaggingSystem : EntitySystem
             string? target;
             if (wagging.Wagging)
             {
-                _coyoteMarking.TryGetStaticId(markings[idx].MarkingId, out target);
+                // Hardlight start
+                _coyoteMarking.TryGetWaggingId(markings[idx].MarkingId, out target);
             }
             else
             {
-                _coyoteMarking.TryGetWaggingId(markings[idx].MarkingId, out target);
+                // Hardlight end
+                _coyoteMarking.TryGetStaticId(markings[idx].MarkingId, out target);
             }
 
             if (target == null)


### PR DESCRIPTION

## About the PR
Fix for https://github.com/HardLightSector/HardLight/issues/1276

## Why / Balance
Tailwag appears to not have loaded properly at the correct moment. This fix makes sure that the WaggingComponent properly initiates if possible

## Technical details
Mainly solved by AI (Junie) but the fix appears to work as intended and further review does not seem like this change would break anything else

## How to test
* Spawn in as a Vulp with either a tail marking that has a waggingId or no markings at all
* See the Action to wag tail
* Click the action
* Wag tail

## Media
<img width="1137" height="746" alt="image" src="https://github.com/user-attachments/assets/75ceae91-9938-4021-94de-d6ebc612f7df" />

**Changelog**

:cl:

- fix: Tail wagging action display
