### PR TITLE
Enabled Xeno Weeds entity to be damageable and killable.

### DIFF
--- a/Resources/Prototypes/.CM14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/.CM14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -155,6 +155,16 @@
     overrides:
     - weed_dir0
     - weed_dir15
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: RandomSprite
     available:
     - 0:


### PR DESCRIPTION
## About the PR
Fixed Xeno Weeds to be destroyable by melee!

## Why / Balance
less Ahelps, less trouble for people!
## Technical details
added a couple tags in XenoWeedsEntity.

## How to test
become Xeno Queen, spawn weeds, destroy weeds. If any persist, is a separate issue that is out of the scope of this PR, relogging removes ghost weeds, as they are clientside.
**Changelog**
:cl:
- fix: Made XenoWeeds killable again!