### PR TITLE
Add chameleon to bluespace bags

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -328,9 +328,19 @@
     maxItemSize: Huge
     grid:
     - 0,0,19,9 # Frontier: Was 0,0,19,9 - FRONTIER MADE IT 0,0,7,7 AND THAT'S DUMB - Loki
+  - type: ChameleonClothing
+    slot: [back]
+    default: ClothingBackpackHolding
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
   - type: Tag
     tags:
     - ScurretWearable
+    - WhitelistChameleon
 
 - type: entity
   parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -258,9 +258,19 @@
       - state: equipped-BACKPACK # Frontier
       - state: equipped-BACKPACK-unlit # Frontier
         shader: unshaded # Frontier
+  - type: ChameleonClothing
+    slot: [back]
+    default: ClothingBackpackDuffelHolding
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
   - type: Tag
     tags:
     - ScurretWearable
+    - WhitelistChameleon
 
 - type: entity
   parent: [ NFClothingDuffel, BaseColcommContraband ] # Frontier: ClothingBackpackDuffel<NFClothingDuffel

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -194,6 +194,16 @@
       - state: equipped-BACKPACK # Frontier
       - state: equipped-BACKPACK-unlit # Frontier
         shader: unshaded # Frontier
+  - type: ChameleonClothing
+    slot: [back]
+    default: ClothingBackpackSatchelHolding
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
   - type: Tag
     tags:
     - ScurretWearable
+    - WhitelistChameleon

--- a/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
@@ -19,7 +19,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.9
-    
+
 - type: entity
   id: ClothingBackpackExplorer
   name: explorer pack
@@ -39,7 +39,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.85
-    
+
 - type: entity
   id: ClothingRucksack
   name: rucksack
@@ -90,3 +90,12 @@
     - 0,11,3,15
     - 5,11,14,15
     - 16,11,19,15
+  - type: ChameleonClothing
+    slot: [back]
+    default: ClothingBackpackTacticalHolding
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
@@ -656,6 +656,19 @@
       - state: inhand-right
       - state: inhand-right-unlit
         shader: unshaded
+  - type: ChameleonClothing
+    slot: [back]
+    default: ClothingBackpackMessengerHolding
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: Tag
+    tags:
+    - ScurretWearable
+    - WhitelistChameleon
 
 ## Antagonists / Contraband
 - type: entity


### PR DESCRIPTION

## About the PR
Add chameleon to bluespace bags

## Why / Balance
Quite a few people asked on discord.
So, since we already have working chameleon backpack, why not?

## Technical details
Tested on all existing backpack slot ones.
Tested that it doesn't get scuffed inside bluespace stash.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1247" height="610" alt="image" src="https://github.com/user-attachments/assets/5c2001a8-8895-4ed8-8d8f-b5d166aa5b11" />


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bluespace bags are now chameleon
