### PR TITLE
Rework Emperor's New Clothing contraband levels

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -475,7 +475,7 @@
         Caustic: 5
 
 - type: entity
-  parent: [ ClothingHandsGlovesColorBlack, BaseC3WizardContraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: [ ClothingHandsGlovesColorBlack ] # BaseSecurityEngineeringContraband<BaseC1Contraband ## Hardlight: Removed BaseC3WizardContraband
   id: ClothingHandsGlovesChameleon
   name: emperor's new gloves
   suffix: Chameleon

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -517,7 +517,7 @@
 
 # Invisible helmet
 - type: entity
-  parent: [ClothingHeadHelmetBase, BaseC3WizardContraband, ContrabandClothing]
+  parent: [ClothingHeadHelmetBase, BaseC1Contraband, ContrabandClothing] ## Hardlight: C3Wizard -> C2
   id: ClothingHeadHelmetChameleon
   name: emperor's new helmet
   suffix: Chameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -379,7 +379,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: [ClothingNude, ClothingOuterBaseLarge, BaseC1, AllowSuitStorageClothing, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContraband, added ContrabandClothing as parent # HardLight: Add ClothingNude, C3Wizard -> C1
+  parent: [ClothingNude, ClothingOuterBaseLarge, BaseC1Contraband, AllowSuitStorageClothing, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContraband, added ContrabandClothing as parent # HardLight: Add ClothingNude, C3Wizard -> C1
   id: ClothingOuterArmorChameleon
   name: emperor's new armour
   suffix: Chameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -379,7 +379,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: [ClothingNude, ClothingOuterBaseLarge, BaseC3WizardContraband, AllowSuitStorageClothing, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContraband, added ContrabandClothing as parent # HardLight: Add ClothingNude
+  parent: [ClothingNude, ClothingOuterBaseLarge, BaseC1, AllowSuitStorageClothing, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContraband, added ContrabandClothing as parent # HardLight: Add ClothingNude, C3Wizard -> C1
   id: ClothingOuterArmorChameleon
   name: emperor's new armour
   suffix: Chameleon


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes the functional chameleon drip not hyper illegal to own.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
None of these made sense. The gloves are a particularly egregious example -- they were C3 despite literally just being chameleon combat gloves. The armour, as well, was C3 despite the _literal previous prototype in the file_ having the **exact same stats** while being C1.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- tweak: Emperor's New Clothing is now C1 or not contra at all.
