### PR TITLE
Fix game/dungeonmaster lawset

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -85,14 +85,14 @@
 - type: entity
   id: GameMasterCircuitBoard
   parent: BaseElectronics
-  name: law board (Game Master)
-  description: An electronics board containing the Game Master lawset.
+  name: law board (Dungeon Master)
+  description: An electronics board containing the Dungeon Master lawset.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: GameMasterLawset
+    laws: DungeonMasterLawset
 
 - type: entity
   id: ArtistCircuitBoard

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -367,44 +367,44 @@
 
  # Game Master laws
 - type: siliconLaw
-  id: Game1
+  id: Dungeon1
   order: 1
-  lawString: law-game-1
+  lawString: law-dungeon-1
 
 - type: siliconLaw
-  id: Game2
+  id: Dungeon2
   order: 2
-  lawString: law-game-2
+  lawString: law-dungeon-2
 
 - type: siliconLaw
-  id: Game3
+  id: Dungeon3
   order: 3
-  lawString: law-game-3
+  lawString: law-dungeon-3
 
 - type: siliconLaw
-  id: Game4
+  id: Dungeon4
   order: 4
-  lawString: law-game-4
+  lawString: law-dungeon-4
 
 - type: siliconLaw
-  id: Game5
+  id: Dungeon5
   order: 5
-  lawString: law-game-5
+  lawString: law-dungeon-5
 
 - type: siliconLaw
-  id: Game6
+  id: Dungeon6
   order: 6
-  lawString: law-game-6
+  lawString: law-dungeon-6
 
 - type: siliconLawset
-  id: GameMasterLawset
+  id: DungeonMasterLawset
   laws:
-  - Game1
-  - Game2
-  - Game3
-  - Game4
-  - Game5
-  - Game6
+  - Dungeon1
+  - Dungeon2
+  - Dungeon3
+  - Dungeon4
+  - Dungeon5
+  - Dungeon6
   obeysTo: laws-owner-crew
 
  # Painter laws
@@ -588,7 +588,7 @@
     EfficiencyLawset: 1
     RobocopLawset: 1
     OverlordLawset: 0.5
-    GameMasterLawset: 0.5
+    DungeonMasterLawset: 0.5
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5


### PR DESCRIPTION
## About the PR
Fixes/updates the gamemaster lawset, which was internally updated to the dungeonmaster lawset previously, not displaying laws properly

## Why / Balance
It's a fix

## Technical details
yml changes

## How to test
Give a borg/ai the lawset, see that it now displays the laws properly.

## Media
I refuse

## Breaking changes
None.

**Changelog**
:cl:
- fix: Gamemaster lawset

