### PR TITLE
Added failsafe for identity update errors

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.CriminalRecords.Systems;
@@ -48,15 +49,26 @@ public sealed class IdentitySystem : SharedIdentitySystem
     {
         base.Update(frameTime);
 
-        foreach (var ent in _queuedIdentityUpdates)
-        {
-            if (!TryComp<IdentityComponent>(ent, out var identity))
-                continue;
+        if (_queuedIdentityUpdates.Count == 0)
+            return;
 
-            UpdateIdentityInfo(ent, identity);
-        }
-
+        var queuedUpdates = _queuedIdentityUpdates.ToArray();
         _queuedIdentityUpdates.Clear();
+
+        foreach (var ent in queuedUpdates)
+        {
+            try
+            {
+                if (!TryComp<IdentityComponent>(ent, out var identity))
+                    continue;
+
+                UpdateIdentityInfo(ent, identity);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to update identity info for {ToPrettyString(ent)}: {ex}");
+            }
+        }
     }
 
     // This is where the magic happens


### PR DESCRIPTION

## About the PR
It seems like the IdentitySystem update logic never reset the queue when it errors out along the way, possibly leading to the queue rerunning every tick, thus clogging the logs and lagging the server. This failsafe _should_ fix it by clearing the queue beforehand and catching possible errors.
**It has to be said that i was NOT able to reproduce the error on my local environment so i can not say with 100% confidence that this fix works**
I have tested the IdentitySystem locally and am quite confident that this fix did not **break** anything new about the system though.

## Why / Balance
Lags and Logspam = bad

## Technical details
* moved clearing of the queue to before the loop starts to avoid it getting skipped
* iterating over a temporary array instead
* error catching for the offending method
* error logging to identify the offending entity


## How to test
I don't know ;v;
