### PR TITLE
Binary/Trinary Update

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -323,13 +323,13 @@
   # HardLight start: Replaced starting encryption keys with intrinsic radio channels.
   - type: ActiveRadio
     intrinsicChannels:
-    - Binary
+    - Trinary # HL: Move RD's headset to Trinary
     - Command
     - Science
     - Common
   - type: EncryptionKeyHolder
     intrinsicChannels:
-    - Binary
+    - Trinary # HL: Move RD's headset to Trinary
     - Command
     - Science
     - Common

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -123,17 +123,20 @@
     examineWhileLocked: false
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   # HardLight end
@@ -391,14 +394,17 @@
     examineWhileLocked: false
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
   # HardLight end
   - type: ShowSyndicateIcons
@@ -436,12 +442,15 @@
     examineWhileLocked: false
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
   # HardLight end
   - type: IonStormTarget
     chance: 1
@@ -483,15 +492,18 @@
     intrinsicChannels:
     - Xenoborg
     - Binary
+    - Trinary # Hardlight
   - type: IntrinsicRadioTransmitter # can only use binary and xenoborg channel
     intrinsicChannels:
     - Xenoborg
     - Binary
+    - Trinary # Hardlight
   - type: ActiveRadio # but can hear the mothership channel
     intrinsicChannels:
     - Mothership
     - Xenoborg
     - Binary
+    - Trinary # Hardlight
   # HardLight end
   - type: BorgChassis
     maxModules: 10

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -157,11 +157,13 @@
     - Mothership
     - Xenoborg
     - Binary
+    - Trinary # Hardlight
   - type: ActiveRadio
     channels:
     - Mothership
     - Xenoborg
     - Binary
+    - Trinary # Hardlight
   - type: Xenoborg
     mindRole: MindRoleMothershipCore
     briefingText: mothership-welcome

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -8,6 +8,7 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
+    - Trinary # Hardlight
     - ColSec
     - Common
     - Command
@@ -24,6 +25,7 @@
   - type: ActiveRadio
     channels:
     - Binary
+    - Trinary # Hardlight
     - ColSec
     - Common
     - Command
@@ -95,9 +97,11 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
+    - Trinary # Hardlight
   - type: ActiveRadio
     channels:
     - Binary
+    - Trinary # Hardlight
     - Common
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -236,11 +236,12 @@
   id: EncryptionKeyBinary
   name: binary translator key
   categories: [ DoNotMap ] # Frontier
-  description: An encryption key that translates binary signals used by silicons.
+  description: An encryption key that translates binary and trinary signals used by silicons. # HL: Add Trinary
   components:
   - type: EncryptionKey
     channels:
     - Binary
+    - Trinary # Hardlight
     defaultChannel: Binary
   - type: Sprite
     layers:
@@ -251,11 +252,12 @@
   parent: [ EncryptionKey, BaseC2ContrabandUnredeemable ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandNoValue
   id: EncryptionKeyBinarySyndicate
   name: binary translator key
-  description: A syndicate encryption key that translates binary signals used by silicons.
+  description: A syndicate encryption key that translates binary and trinary signals used by silicons. # HL: Add Trinary
   components:
   - type: EncryptionKey
     channels:
     - Binary
+    - Trinary # Hardlight
     defaultChannel: Binary
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -236,12 +236,12 @@
   id: EncryptionKeyBinary
   name: binary translator key
   categories: [ DoNotMap ] # Frontier
-  description: An encryption key that translates binary and trinary signals used by silicons. # HL: Add Trinary
+  description: An encryption key that translates binary signals used by silicons.
   components:
   - type: EncryptionKey
     channels:
     - Binary
-    - Trinary # Hardlight
+    # - Trinary # Hardlight - uncomment when we figure out how to not duplicate this w/ Synthetic
     defaultChannel: Binary
   - type: Sprite
     layers:
@@ -252,12 +252,12 @@
   parent: [ EncryptionKey, BaseC2ContrabandUnredeemable ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandNoValue
   id: EncryptionKeyBinarySyndicate
   name: binary translator key
-  description: A syndicate encryption key that translates binary and trinary signals used by silicons. # HL: Add Trinary
+  description: A syndicate encryption key that translates binary signals used by silicons.
   components:
   - type: EncryptionKey
     channels:
     - Binary
-    - Trinary # Hardlight
+    # - Trinary # Hardlight - uncomment when we figure out how to not duplicate this w/ Synthetic
     defaultChannel: Binary
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -22,9 +22,11 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
+    - Trinary # Hardlight
   - type: ActiveRadio
     channels:
     - Binary
+    - Trinary # Hardlight
     - Common
   - type: NameIdentifier
     group: MMI

--- a/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -67,16 +67,19 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Common
   # HardLight end
@@ -153,6 +156,7 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColSec
     - Security
     - Science
@@ -160,6 +164,7 @@
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColSec
     - Security
     - Science
@@ -167,6 +172,7 @@
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColSec
     - Security
     - Science
@@ -226,16 +232,19 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Syndicate
     - Common
   # HardLight end
@@ -297,6 +306,7 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColCom
     - Command
     - ColSec
@@ -310,6 +320,7 @@
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColCom
     - Command
     - ColSec
@@ -323,6 +334,7 @@
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - ColCom
     - Command
     - ColSec
@@ -401,18 +413,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Supply
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Supply
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Supply
     - Common
@@ -470,18 +485,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Service
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Service
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Science
     - Service
     - Common
@@ -540,18 +558,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Engineering
     - Science
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Engineering
     - Science
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Engineering
     - Science
     - Common
@@ -614,18 +635,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Medical
     - Science
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Medical
     - Science
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary # Hardlight
     - Medical
     - Science
     - Common

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -14,3 +14,10 @@
   # End DeltaV Additions - blacklist IPCs
   components:
     - type: Synth
+    - type: IntrinsicRadioReceiver # Hardlight start: Give you Trinary
+    - type: IntrinsicRadioTransmitter
+      intrinsicChannels:
+      - Trinary
+    - type: ActiveRadio
+      intrinsicChannels:
+      - Trinary

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -21,3 +21,9 @@
     - type: ActiveRadio
       intrinsicChannels:
       - Trinary
+    - type: EncryptionKeyHolder
+      keySlots: 1
+      examineWhileLocked: false
+      preserveExistingChannels: true
+      intrinsicChannels:
+      - Trinary

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -155,15 +155,15 @@
     keysUnlocked: false
     preserveExistingChannels: true
     intrinsicChannels:
-    - Binary
+    - Trinary # Hardlight: No binary for you
   - type: OfferItem # HL
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
-    - Binary
+    - Trinary # Hardlight: No binary for you
   - type: ActiveRadio
     intrinsicChannels:
-    - Binary
+    - Trinary # Hardlight: No binary for you
   - type: DeadStartupButton
     sound:
       path: /Audio/_EE/Effects/Silicon/startup.ogg

--- a/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/DogBorg.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/DogBorg.yml
@@ -30,6 +30,7 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science
@@ -37,6 +38,7 @@
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science
@@ -44,6 +46,7 @@
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science

--- a/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/Gl1tzBorg.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/Gl1tzBorg.yml
@@ -29,6 +29,7 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science
@@ -36,6 +37,7 @@
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science
@@ -43,6 +45,7 @@
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary
     - ColSec
     - Security
     - Science

--- a/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/PetalBorg.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/PetalBorg.yml
@@ -29,18 +29,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary
     - Medical
     - Science
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary
     - Medical
     - Science
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary
     - Medical
     - Science
     - Common

--- a/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/RaptBorg.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Cyborg/RaptBorg.yml
@@ -37,12 +37,14 @@
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: ActiveRadio
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: BorgChassis
@@ -122,12 +124,14 @@
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: ActiveRadio
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: BorgChassis
@@ -207,12 +211,14 @@
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: ActiveRadio
     channels:
     - Security
     - Binary
+    - Trinary
     - Common
     - Science
   - type: BorgChassis

--- a/Resources/Prototypes/_HL/Entities/Mobs/Player/Quads.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Player/Quads.yml
@@ -133,18 +133,21 @@
     preserveExistingChannels: true
     intrinsicChannels:
     - Binary
+    - Trinary
     - Science
     - Service
     - Common
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
     - Binary
+    - Trinary
     - Science
     - Service
     - Common
   - type: ActiveRadio
     intrinsicChannels:
     - Binary
+    - Trinary
     - Science
     - Service
     - Common

--- a/Resources/Prototypes/_HL/Entities/Mobs/Species/synth.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Species/synth.yml
@@ -98,14 +98,14 @@
     examineWhileLocked: false
     preserveExistingChannels: true
     intrinsicChannels:
-    - Binary
+    - Trinary
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     intrinsicChannels:
-    - Binary
+    - Trinary
   - type: ActiveRadio
     intrinsicChannels:
-    - Binary
+    - Trinary
   - type: Bloodstream
     bloodReagent: InertNanites
     bloodRefreshAmount: 0.0


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes Binary from Synths, IPCs, and the RD -- switches them to Trinary instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Binary is supposed to be restricted to law-bound Silicons. Right now, it's basically just another Common for Synths and IPCs. We already have Trinary, which was used by Protogens, so they get that instead.

Several species having it also undermines the Syndicate Binary Translator encryption key. Why buy it when you can just be a synth or IPC?

All silicons that have binary have been given Trinary as well, as well as the RD being given it.
The Synthetic trait now also gives you access to it.
## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- remove: Synths and IPCs no longer get Binary access (instead Trinary).
- remove: The RD no longer gets Binary access (instead Trinary).
- add: Synthetic trait now gives you access to Trinary.