### PR TITLE
Nullspace fixes and sec and syndies items

### DIFF
--- a/Content.Client/_Starlight/NullSpace/BluespaceFlasherRadiusOverlay.cs
+++ b/Content.Client/_Starlight/NullSpace/BluespaceFlasherRadiusOverlay.cs
@@ -1,0 +1,42 @@
+using Content.Shared._Starlight.NullSpace;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+
+namespace Content.Client._Starlight.NullSpace;
+
+public sealed class BluespaceFlasherRadiusOverlay : global::Robust.Client.Graphics.Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    private readonly TransformSystem _xform;
+
+    private static readonly Color FillColor = new(0.2f, 0.5f, 1f, 0.08f);
+    private static readonly Color BorderColor = new(0.3f, 0.6f, 1f, 0.55f);
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
+
+    public BluespaceFlasherRadiusOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _xform = _entityManager.System<TransformSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var handle = args.WorldHandle;
+        var mapId = args.MapId;
+
+        var query = _entityManager.EntityQueryEnumerator<BluespaceFlasherVisualsComponent, TransformComponent>();
+        while (query.MoveNext(out _, out var visuals, out var xform))
+        {
+            if (xform.MapID != mapId)
+                continue;
+
+            var worldPos = _xform.GetWorldPosition(xform);
+            handle.DrawCircle(worldPos, visuals.Radius, FillColor, filled: true);
+            handle.DrawCircle(worldPos, visuals.Radius, BorderColor, filled: false);
+        }
+    }
+}

--- a/Content.Client/_Starlight/NullSpaceSystem.cs
+++ b/Content.Client/_Starlight/NullSpaceSystem.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Physics.Events;
 using Content.Shared._Starlight.NullSpace;
 using Robust.Shared.Prototypes;
 using Content.Client._Starlight.Overlay;
+using Content.Client._Starlight.NullSpace;
 
 namespace Content.Client._Starlight;
 
@@ -16,6 +17,7 @@ public sealed partial class EtherealSystem : EntitySystem
     private static readonly ProtoId<ShaderPrototype> NullSpaceShaderId = "NullSpaceShader";
 
     private NullSpaceOverlay _overlay = default!;
+    private BluespaceFlasherRadiusOverlay? _flasherOverlay;
 
     public override void Initialize()
     {
@@ -27,6 +29,11 @@ public sealed partial class EtherealSystem : EntitySystem
         SubscribeLocalEvent<NullSpaceComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<NullSpaceComponent, PreventCollideEvent>(PreventCollision);
 
+        SubscribeLocalEvent<ShowNullSpaceComponent, ComponentInit>(OnShowInit);
+        SubscribeLocalEvent<ShowNullSpaceComponent, ComponentShutdown>(OnShowShutdown);
+        SubscribeLocalEvent<ShowNullSpaceComponent, LocalPlayerAttachedEvent>(OnShowPlayerAttached);
+        SubscribeLocalEvent<ShowNullSpaceComponent, LocalPlayerDetachedEvent>(OnShowPlayerDetached);
+
         _overlay = new(_prototypeManager.Index(NullSpaceShaderId));
     }
 
@@ -36,6 +43,7 @@ public sealed partial class EtherealSystem : EntitySystem
             return;
 
         _overlayMan.AddOverlay(_overlay);
+        AddFlasherOverlay();
     }
 
     private void OnShutdown(EntityUid uid, NullSpaceComponent component, ComponentShutdown args)
@@ -44,16 +52,61 @@ public sealed partial class EtherealSystem : EntitySystem
             return;
 
         _overlayMan.RemoveOverlay(_overlay);
+        if (!HasComp<ShowNullSpaceComponent>(uid))
+            RemoveFlasherOverlay();
     }
 
     private void OnPlayerAttached(EntityUid uid, NullSpaceComponent component, LocalPlayerAttachedEvent args)
     {
         _overlayMan.AddOverlay(_overlay);
+        AddFlasherOverlay();
     }
 
     private void OnPlayerDetached(EntityUid uid, NullSpaceComponent component, LocalPlayerDetachedEvent args)
     {
         _overlayMan.RemoveOverlay(_overlay);
+        if (!HasComp<ShowNullSpaceComponent>(uid))
+            RemoveFlasherOverlay();
+    }
+
+    private void OnShowInit(EntityUid uid, ShowNullSpaceComponent component, ComponentInit args)
+    {
+        if (uid != _playerMan.LocalEntity)
+            return;
+        AddFlasherOverlay();
+    }
+
+    private void OnShowShutdown(EntityUid uid, ShowNullSpaceComponent component, ComponentShutdown args)
+    {
+        if (uid != _playerMan.LocalEntity)
+            return;
+        if (!HasComp<NullSpaceComponent>(uid))
+            RemoveFlasherOverlay();
+    }
+
+    private void OnShowPlayerAttached(EntityUid uid, ShowNullSpaceComponent component, LocalPlayerAttachedEvent args)
+    {
+        AddFlasherOverlay();
+    }
+
+    private void OnShowPlayerDetached(EntityUid uid, ShowNullSpaceComponent component, LocalPlayerDetachedEvent args)
+    {
+        if (!HasComp<NullSpaceComponent>(uid))
+            RemoveFlasherOverlay();
+    }
+
+    private void AddFlasherOverlay()
+    {
+        if (_overlayMan.HasOverlay<BluespaceFlasherRadiusOverlay>())
+            return;
+        _flasherOverlay = new BluespaceFlasherRadiusOverlay();
+        _overlayMan.AddOverlay(_flasherOverlay);
+    }
+
+    private void RemoveFlasherOverlay()
+    {
+        _overlayMan.RemoveOverlay<BluespaceFlasherRadiusOverlay>();
+        _flasherOverlay = null;
     }
 
     private void PreventCollision(EntityUid uid, NullSpaceComponent component, ref PreventCollideEvent args)

--- a/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
+++ b/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
@@ -115,6 +115,11 @@ public static class ShipSaveYamlSanitizer
         "PortalRed",
         "ReactorGasPipe",
         "ShipShield",
+        // NullSpace items
+        "ClothingEyesGlassesNullSpace",
+        "BluespaceFlasher",
+        "ClothingNullHarness",
+        "ClothingNullSpaceTeleporter",
     };
 
     // Entity-level exclusion by component signature.

--- a/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerComponent.cs
+++ b/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerComponent.cs
@@ -1,12 +1,13 @@
-using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server._Starlight.NullSpace;
 
 /// <summary>
-/// Component that causes a Bluespace pulse when the owner is triggered.
-/// Used with TriggerOnProximity to purge NullSpace entities and stun them.
+/// Component that actively scans for NullSpace entities and pulses to remove them.
+/// Replaces proximity-trigger detection which NullSpace entities can't participate in
+/// (their physics contacts are all cancelled).
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class BluespacePulseOnTriggerComponent : Component
 {
     [DataField]
@@ -14,4 +15,10 @@ public sealed partial class BluespacePulseOnTriggerComponent : Component
 
     [DataField]
     public float StunSeconds = 4f;
+
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(5);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextTrigger;
 }

--- a/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared._Starlight.NullSpace;
+using Content.Shared._Starlight;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -54,7 +55,8 @@ public sealed class BluespacePulseOnTriggerSystem : EntitySystem
             var stunTime = TimeSpan.FromSeconds(comp.StunSeconds);
             foreach (var ent in found)
             {
-                _audio.PlayPvs(NullSpaceCutoffSound, ent);
+                if (HasComp<ShadekinComponent>(ent))
+                    _audio.PlayPvs(NullSpaceCutoffSound, ent);
                 RemComp<NullSpaceComponent>(ent);
                 _stun.TryParalyze(ent, stunTime, true);
             }

--- a/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
@@ -1,30 +1,63 @@
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared._Starlight.NullSpace;
+using Content.Shared.Stunnable;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Server._Starlight.NullSpace;
 
 /// <summary>
-/// Listens for TriggerEvent on entities with BluespacePulseOnTriggerComponent
-/// and raises a BluespacePulseActionEvent to purge NullSpace in a radius.
+/// Periodically scans for NullSpace entities within range and pulses to remove them + stun.
+/// Uses Update-based detection instead of TriggerOnProximity because NullSpace entities
+/// cancel all physics contacts, making physics-based proximity sensors blind to them.
 /// </summary>
 public sealed class BluespacePulseOnTriggerSystem : EntitySystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<BluespacePulseOnTriggerComponent, TriggerEvent>(OnTrigger);
-    }
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
 
-    private void OnTrigger(Entity<BluespacePulseOnTriggerComponent> ent, ref TriggerEvent args)
+    private static readonly SoundPathSpecifier NullSpaceCutoffSound = new("/Audio/_HL/Effects/ma cutoff.ogg");
+
+    public override void Update(float frameTime)
     {
-        var pulse = new BluespacePulseActionEvent
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<BluespacePulseOnTriggerComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var comp, out var xform))
         {
-            Radius = ent.Comp.Radius,
-            StunSeconds = ent.Comp.StunSeconds,
-            Performer = args.User ?? ent.Owner
-        };
+            if (curTime < comp.NextTrigger)
+                continue;
 
-        RaiseLocalEvent(pulse);
-        args.Handled = true;
+            // Collect NullSpace entities in range before modifying any components
+            var found = new List<EntityUid>();
+            foreach (var ent in _lookup.GetEntitiesInRange(uid, comp.Radius))
+            {
+                if (HasComp<NullSpaceComponent>(ent))
+                    found.Add(ent);
+            }
+
+            if (found.Count == 0)
+                continue;
+
+            comp.NextTrigger = curTime + comp.Cooldown;
+
+            // Fire effects (EmitSoundOnTrigger + SpawnOnTrigger)
+            _trigger.Trigger(uid);
+
+            // Remove NullSpace and stun all detected entities
+            var stunTime = TimeSpan.FromSeconds(comp.StunSeconds);
+            foreach (var ent in found)
+            {
+                _audio.PlayPvs(NullSpaceCutoffSound, ent);
+                RemComp<NullSpaceComponent>(ent);
+                _stun.TryParalyze(ent, stunTime, true);
+            }
+        }
     }
 }

--- a/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
@@ -36,6 +36,8 @@ public sealed class EtherealPhaseSystem : EntitySystem
         SubscribeLocalEvent<NullPhaseComponent, GotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<NullPhaseComponent, GotUnequippedEvent>(OnUnequipped);
         SubscribeLocalEvent<NullPhaseComponent, NullPhaseActionEvent>(OnPhaseAction);
+        SubscribeLocalEvent<NullHarnessComponent, GotEquippedEvent>(OnHarnessEquipped);
+        SubscribeLocalEvent<NullHarnessComponent, GotUnequippedEvent>(OnHarnessUnequipped);
     }
 
     private void OnStartup(EntityUid uid, NullPhaseComponent component, ComponentStartup args)
@@ -62,8 +64,28 @@ public sealed class EtherealPhaseSystem : EntitySystem
         RemComp<NullPhaseComponent>(args.Equipee);
     }
 
+    private void OnHarnessEquipped(EntityUid uid, NullHarnessComponent component, GotEquippedEvent args)
+    {
+        if (!TryComp<ClothingComponent>(uid, out var clothing) || !clothing.Slots.HasFlag(args.SlotFlags))
+            return;
+
+        EnsureComp<BlockNullPhaseComponent>(args.Equipee);
+    }
+
+    private void OnHarnessUnequipped(EntityUid uid, NullHarnessComponent component, GotUnequippedEvent args)
+    {
+        RemComp<BlockNullPhaseComponent>(args.Equipee);
+    }
+
     private void OnPhaseAction(EntityUid uid, NullPhaseComponent component, NullPhaseActionEvent args)
     {
+        if (HasComp<BlockNullPhaseComponent>(args.Performer))
+        {
+            _popup.PopupEntity(Loc.GetString("null-harness-blocks-phase"), args.Performer, args.Performer);
+            args.Handled = true;
+            return;
+        }
+
         // Perform phase on the user performing the action, not the provider entity.
         Phase(args.Performer);
         args.Handled = true;

--- a/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
@@ -72,7 +72,11 @@ public sealed class EtherealPhaseSystem : EntitySystem
     private void Toggle(EntityUid uid, NullPhaseComponent component, bool toggle)
     {
         if (toggle)
+        {
             _actionsSystem.AddAction(uid, ref component.PhaseAction, "NullPhaseAction", uid);
+            if (component.UseDelay.HasValue)
+                _actionsSystem.SetUseDelay(component.PhaseAction, TimeSpan.FromSeconds(component.UseDelay.Value));
+        }
         else
             _actionsSystem.RemoveAction(uid, component.PhaseAction);
     }

--- a/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared._Starlight.NullSpace;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Carrying;
 using Content.Shared.Stunnable;
 using Robust.Shared.Player;
 using Robust.Shared.Audio;
@@ -28,6 +29,7 @@ public sealed class EtherealSystem : SharedEtherealSystem
     [Dependency] private readonly EyeSystem _eye = default!;
     [Dependency] private readonly NpcFactionSystem _factions = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
+    [Dependency] private readonly CarryingSystem _carrying = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -72,6 +74,12 @@ public sealed class EtherealSystem : SharedEtherealSystem
         {
             _pulling.TryStopPull(pullerComp.Pulling.Value, subjectPulling);
         }
+
+        if (TryComp<CarryingComponent>(uid, out var carrying))
+            _carrying.DropCarried(uid, carrying.Carried);
+
+        if (TryComp<BeingCarriedComponent>(uid, out var beingCarried))
+            _carrying.DropCarried(beingCarried.Carrier, uid);
     }
 
     public override void OnShutdown(EntityUid uid, NullSpaceComponent component, ComponentShutdown args)

--- a/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Stunnable;
 using Robust.Shared.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Content.Shared._Starlight;
 
 namespace Content.Server._Starlight.NullSpace;
 
@@ -29,7 +30,6 @@ public sealed class EtherealSystem : SharedEtherealSystem
     [Dependency] private readonly EyeSystem _eye = default!;
     [Dependency] private readonly NpcFactionSystem _factions = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
-    [Dependency] private readonly CarryingSystem _carrying = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -39,6 +39,14 @@ public sealed class EtherealSystem : SharedEtherealSystem
         base.Initialize();
         SubscribeLocalEvent<NullSpaceComponent, AtmosExposedGetAirEvent>(OnExpose);
         SubscribeLocalEvent<BluespacePulseActionEvent>(OnBluespacePulse);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<NullSpaceComponent, KnockedDownComponent>();
+        while (query.MoveNext(out var uid, out _, out _))
+            RemCompDeferred<NullSpaceComponent>(uid);
     }
 
     public override void OnStartup(EntityUid uid, NullSpaceComponent component, MapInitEvent args)
@@ -76,10 +84,7 @@ public sealed class EtherealSystem : SharedEtherealSystem
         }
 
         if (TryComp<CarryingComponent>(uid, out var carrying))
-            _carrying.DropCarried(uid, carrying.Carried);
-
-        if (TryComp<BeingCarriedComponent>(uid, out var beingCarried))
-            _carrying.DropCarried(beingCarried.Carrier, uid);
+            EnsureComp<PressureImmunityComponent>(carrying.Carried);
     }
 
     public override void OnShutdown(EntityUid uid, NullSpaceComponent component, ComponentShutdown args)
@@ -94,7 +99,12 @@ public sealed class EtherealSystem : SharedEtherealSystem
         }
 
         if (TryComp<EyeComponent>(uid, out var eye))
-            _eye.SetVisibilityMask(uid, (int)VisibilityFlags.Normal, eye);
+        {
+            var mask = (int)VisibilityFlags.Normal;
+            if (HasComp<ShowNullSpaceComponent>(uid))
+                mask |= (int)VisibilityFlags.NullSpace;
+            _eye.SetVisibilityMask(uid, mask, eye);
+        }
 
         if (TryComp<TemperatureComponent>(uid, out var temp))
             temp.AtmosTemperatureTransferEfficiency = 0.1f;
@@ -115,6 +125,9 @@ public sealed class EtherealSystem : SharedEtherealSystem
         {
             _pulling.TryStopPull(pullerComp.Pulling.Value, subjectPulling);
         }
+
+        if (TryComp<CarryingComponent>(uid, out var carrying))
+            RemComp<PressureImmunityComponent>(carrying.Carried);
     }
 
     public void SuppressFactions(EntityUid uid, NullSpaceComponent component, bool set)
@@ -158,7 +171,8 @@ public sealed class EtherealSystem : SharedEtherealSystem
             if (!HasComp<NullSpaceComponent>(ent))
                 continue;
 
-            _audio.PlayPvs(NullSpaceCutoffSound, ent);
+            if (HasComp<ShadekinComponent>(ent))
+                _audio.PlayPvs(NullSpaceCutoffSound, ent);
             RemComp<NullSpaceComponent>(ent);
             _stun.TryParalyze(ent, stunTime, true);
         }

--- a/Content.Shared/_Starlight/NullSpace/BlockNullPhaseComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/BlockNullPhaseComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._Starlight.NullSpace;
+
+[RegisterComponent]
+public sealed partial class BlockNullPhaseComponent : Component { }

--- a/Content.Shared/_Starlight/NullSpace/BluespaceFlasherVisualsComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/BluespaceFlasherVisualsComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.NullSpace;
+
+/// <summary>
+/// Marks an entity as a bluespace flasher and stores its trigger radius for client-side NullSpace rendering.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BluespaceFlasherVisualsComponent : Component
+{
+    [DataField]
+    public float Radius = 10f;
+}

--- a/Content.Shared/_Starlight/NullSpace/NullHarnessComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/NullHarnessComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._Starlight.NullSpace;
+
+[RegisterComponent]
+public sealed partial class NullHarnessComponent : Component { }

--- a/Content.Shared/_Starlight/NullSpace/NullPhaseComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/NullPhaseComponent.cs
@@ -5,4 +5,10 @@ public sealed partial class NullPhaseComponent : Component
 {
     [DataField]
     public EntityUid? PhaseAction;
+
+    /// <summary>
+    /// Overrides the Phase Shift action's use delay in seconds. If null, the action prototype default is used.
+    /// </summary>
+    [DataField]
+    public float? UseDelay;
 }

--- a/Content.Shared/_Starlight/NullSpace/SharedNullSpaceSystem.cs
+++ b/Content.Shared/_Starlight/NullSpace/SharedNullSpaceSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Ranged.Events;
@@ -85,6 +86,8 @@ public abstract class SharedEtherealSystem : EntitySystem
 
     private void PreventCollision(EntityUid uid, NullSpaceComponent component, ref PreventCollideEvent args)
     {
+        if (HasComp<StaminaDamageOnCollideComponent>(args.OtherEntity))
+            return;
         if (!_net.IsClient)
             args.Cancelled = true;
     }

--- a/Content.Shared/_Starlight/NullSpace/ShowNullSpaceComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/ShowNullSpaceComponent.cs
@@ -1,4 +1,6 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared._Starlight.NullSpace;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class ShowNullSpaceComponent : Component { }

--- a/Resources/Locale/en-US/_HL/store/Syndicateuplink.ftl
+++ b/Resources/Locale/en-US/_HL/store/Syndicateuplink.ftl
@@ -9,3 +9,12 @@ uplink-toolbelt-desc = It can hold various tools while looking fresh as fuck. Co
 # Armor
 uplink-clothing-chameleon-thieving-gloves-name = chameleon thieving gloves
 uplink-clothing-chameleon-thieving-gloves-desc = Discreetly steal from pockets and improve your thieving technique with these fancy new gloves. They can change appearance to match any pair of gloves!
+
+# NullSpace
+uplink-nullspace-teleporter-name = nullspace teleporter
+uplink-nullspace-teleporter-desc = A bluespace backpack that lets you phase in and out of NullSpace. Originally developed during experiments on Shadekin.
+
+uplink-nullspace-goggles-name = nullspace goggles
+uplink-nullspace-goggles-desc = Unusual goggles that let you peer into NullSpace, seeing those who hide within.
+
+null-harness-blocks-phase = The null harness prevents you from entering NullSpace!

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -34,6 +34,9 @@
     FoodBoxDonut: 2 
     SecurityStimpack: 4 # _CD
     TrackingImplanter: 5
+    ClothingEyesGlassesNullSpace: 4
+    BluespaceFlasher: 4
+    ClothingNullHarness: 4
   # contrabandInventory: # Frontier
   #   WeaponMeleeNeedle: 2 # Frontier
   #   FoodDonutHomer: 12 # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -243,18 +243,9 @@
     - type: BluespacePulseOnTrigger
       radius: 10
       stunSeconds: 4
+      cooldown: 5
     - type: BluespaceFlasherVisuals
       radius: 10
-    - type: TriggerOnProximity
-      enabled: true
-      cooldown: 5
-      shape:
-        !type:PhysShapeCircle
-          radius: 10
-      triggerSpeed: 0.1
-      whitelist:
-        components:
-        - NullSpace
     - type: Sprite
       sprite: _HL/Objects/Weapons/bflash.rsi
       layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -243,6 +243,8 @@
     - type: BluespacePulseOnTrigger
       radius: 10
       stunSeconds: 4
+    - type: BluespaceFlasherVisuals
+      radius: 10
     - type: TriggerOnProximity
       enabled: true
       cooldown: 5

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -1,3 +1,27 @@
+# NullSpace
+
+- type: listing
+  id: UplinkNullSpaceTeleporter
+  name: uplink-nullspace-teleporter-name
+  description: uplink-nullspace-teleporter-desc
+  productEntity: ClothingNullSpaceTeleporter
+  icon: { sprite: /Textures/_Starlight/Clothing/Back/nullspaceteleporter.rsi, state: icon }
+  cost:
+    Telecrystal: 20
+  categories:
+  - UplinkWearables
+
+- type: listing
+  id: UplinkNullSpaceGoggles
+  name: uplink-nullspace-goggles-name
+  description: uplink-nullspace-goggles-desc
+  productEntity: ClothingEyesGlassesNullSpace
+  icon: { sprite: /Textures/_Starlight/Clothing/Eyes/Glasses/nullspacegoogles.rsi, state: icon }
+  cost:
+    Telecrystal: 5
+  categories:
+  - UplinkWearables
+
 # Cybernetics
 
 - type: listing

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullharness.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullharness.yml
@@ -1,0 +1,18 @@
+- type: entity
+  parent: [Clothing, BaseC1Contraband]
+  id: ClothingNullHarness
+  name: null harness
+  description: A security harness reinforced with bluespace crystals. Prevents the wearer from entering NullSpace. Cannot be removed by the wearer themselves.
+  components:
+    - type: Sprite
+      sprite: Clothing/Back/Backpacks/ertsec.rsi
+      state: icon
+    - type: Item
+      size: Normal
+    - type: Clothing
+      slots: BACK
+      sprite: Clothing/Back/Backpacks/ertsec.rsi
+    - type: SelfUnremovableClothing
+    - type: NullHarness
+    - type: StaticPrice
+      price: 200

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullspaceteleporter.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullspaceteleporter.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [Clothing, BaseC2Contraband]
+  parent: [Clothing, BaseC3Contraband]
   id: ClothingNullSpaceTeleporter
   name: nullspace teleporter
   description: Originally created while several research facilities were experimenting on Shadekin, this backpack allows the wearer to jump the gap between the "normal" dimension and NullSpace.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullspaceteleporter.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/nullspaceteleporter.yml
@@ -16,3 +16,4 @@
       slots: BACK
       sprite: _Starlight/Clothing/Back/nullspaceteleporter.rsi
     - type: NullPhase
+      useDelay: 60

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingEyesBase, BaseC2Contraband]
+  parent: [ClothingEyesBase, BaseC1Contraband]
   id: ClothingEyesGlassesNullSpace
   name: nullspace goggles
   description: An unusual pair of goggles developed during a time of inhumane experimentation involving Shadekin. They are designed to allow the wearer to peer into NullSpace.


### PR DESCRIPTION

## About the PR
NullSpace system bug fixes, balance tweaks, and new content to give security meaningful counterplay against Shadekin and nullspace teleporter users. 

  - Null harness (ClothingNullHarness) — a back-slot harness that prevents
   the wearer from entering NullSpace and cannot be self-removed (like the
   electropack). C1 contraband.
  - Nullspace teleporter and goggles added to the Syndicate uplink (20 TC
  and 5 TC respectively).
  - Goggles, bluespace flashers, and null harnesses added to the SecTech
  vendor (4 of each).
  - All four NullSpace items blacklisted from ship saves so they don't
  persist on exported grids.

  - Nullspace teleporter reclassified C2 → C3 contraband.
  - Nullspace goggles reclassified C2 → C1 contraband.
  - Nullspace can be targeted not only by lasers as before, but by disabler bolts as well. Crit or stamina crit forces nullspace user out.

## Why / Balance
NullSpace currently has no reliable security countermeasures. The bluespace flasher was non-functional (explained below), goggles were too restricted to obtain, and there was no way to physically restrain a nullphaser. This PR gives security a toolkit: goggles to see NullSpace threats, flashers that actually work to eject them, and harnesses to permanently lock a suspect out of NullSpace. The teleporter moves to C3 to reflect its power level; goggles drop to C1 since they're purely  informational.

## Technical details
Bluespace flasher fixes
Flasher radius overlay
Goggles visibility fix on exiting nullspace
Knockdown exits NullSpace
Disablers now hit NullSpace entities
"ma cutoff" sound scoped to Shadekin only
Carry pressure immunity (walls don't crush your lovers)
Added null harness

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Null harness and nullspace-related fixes
-->
