### PR TITLE
Fix the AME math

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -179,7 +179,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
-        return 90000f * fuel * fuel / cores; // Hardlight: 2000000f -> 90000f (8MW -> 180kW)
+        return 45000f * fuel * fuel / cores; // Hardlight: 2000000f -> 90000f (8MW -> 180kW)
     }
 
     public int GetTotalStability()


### PR DESCRIPTION

## About the PR
Fixes a small miscalculation in the AME's math to make it produce what it was MEANT to.

## Why / Balance
After a lot of debate it was decided that the AME shall be producing 180kw. https://github.com/HardLightSector/HardLight/pull/1243 implemented this. Well, almost. Thanks to a small miscalculation in the formula, this PR made the AME produce 360kw, not 180kw. So I fixed it. I swear, this is the last time we're touching it.

## Technical details
Halves the float value that's being used for calculations.

## How to test
Boot up dev env.
Build an AME with 1 core
Insert fuel
Look at target power.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: R3v3l4t1on
- fix: The AME now ACTUALLY produces 180kw per core.
