### PR TITLE
Restore plant random chemicals&gasses removed by #1288

### DIFF
--- a/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
@@ -35,8 +35,8 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
           Gas.Ammonia,
           Gas.Plasma,
           Gas.WaterVapor,
-          //Gas.Tritium,
-          //Gas.Frezon,
+          Gas.Tritium,
+          Gas.Frezon,
         };
         // End Frontier: List of gasses
 
@@ -90,8 +90,8 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
           Gas.Ammonia,
           Gas.Plasma,
           Gas.WaterVapor,
-          //Gas.Tritium,
-          //Gas.Frezon,
+          Gas.Tritium,
+          Gas.Frezon,
         };
         // End Frontier: List of gasses
 

--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -5,11 +5,14 @@
     weight: 0.5
     reagents:
     - Omnizine
+    - Nocturine
+    - Lexorin
     - Impedrezene
     - Fresium
     - HeartbreakerToxin
     - Honk
     - BuzzochloricBees
+    - Stimulants
     - Libidozenithizine
     - Lithium
   - quantity: 5
@@ -89,6 +92,7 @@
     - Ash
     - SodiumCarbonate
     - SpaceDrugs
+    - MuteToxin
     - SpaceGlue
     - JuiceBerryPoison
     - Pilk

--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -5,11 +5,11 @@
     weight: 0.5
     reagents:
     - Omnizine
-    - Nocturine
-    - Lexorin
+    - Impedrezene
+    - Fresium
+    - HeartbreakerToxin
     - Honk
     - BuzzochloricBees
-    - Stimulants
     - Libidozenithizine
     - Lithium
   - quantity: 5
@@ -35,6 +35,9 @@
     - JuiceThatMakesYouWeh
     - JuiceThatMakesYouHew
     - JuiceThatMakesYouBark
+    - TearGas
+    - Lipolicide
+    - Benzene
     - Philterex
   - quantity: 5
     weight: 2
@@ -62,6 +65,8 @@
     - Cola
     - Diphenhydramine
     - Iron
+    - Bleach
+    - Mannitol
     - Iodine
   - quantity: 10
     weight: 3
@@ -84,7 +89,7 @@
     - Ash
     - SodiumCarbonate
     - SpaceDrugs
-    - MuteToxin
+    - SpaceGlue
     - JuiceBerryPoison
     - Pilk
     - Posca
@@ -97,6 +102,9 @@
     - Potassium
     - Fluorine
     - Aluminium
+    - Wine
+    - Coffee
+    - Beer
   - quantity: 10
     weight: 3.5
     reagents:


### PR DESCRIPTION
## About the PR
Restores randomly mutatable chemicals and gasses that were disabled by [Pull 1288](https://github.com/HardLightSector/HardLight/pull/1288)

## Why / Balance
Pull 1288's mass rollbacks seem to have removed these unintentionally.