### PR TITLE
Nuke salvage exped computers

### DIFF
--- a/Resources/hl_migration.yml
+++ b/Resources/hl_migration.yml
@@ -1,0 +1,2 @@
+# 22-04-2026 BEGONE EXPED COMPUTERS
+ComputerSalvageExpedition: null


### PR DESCRIPTION

## About the PR
Title

## Why / Balance
Stops people accidentally taking the station on expedition

## Technical details
Uses migration to remove ComputerSalvageExpedition from all maps

## How to test
Load box. 
Verify the damn computer is gone

## Media


## Breaking changes
Well it removes the entity from all maps so if downstreams want to keep it don't merge

**Changelog**
:cl: R3v3l4t1on
- add: Added fun!
- remove: Removed the salvage expedition computer from every single map. 
