### PR TITLE
Prevent unintended entities from triggering nullspace pull

### DIFF
--- a/Content.Client/_Starlight/NullSpace/BluespaceFlasherRadiusOverlay.cs
+++ b/Content.Client/_Starlight/NullSpace/BluespaceFlasherRadiusOverlay.cs
@@ -31,7 +31,7 @@ public sealed class BluespaceFlasherRadiusOverlay : global::Robust.Client.Graphi
         var query = _entityManager.EntityQueryEnumerator<BluespaceFlasherVisualsComponent, TransformComponent>();
         while (query.MoveNext(out _, out var visuals, out var xform))
         {
-            if (xform.MapID != mapId)
+            if (xform.MapID != mapId || !xform.Anchored)
                 continue;
 
             var worldPos = _xform.GetWorldPosition(xform);

--- a/Content.IntegrationTests/Tests/StationRecords/GeneralStationRecordConsoleTest.cs
+++ b/Content.IntegrationTests/Tests/StationRecords/GeneralStationRecordConsoleTest.cs
@@ -19,6 +19,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+#nullable enable
 
 namespace Content.IntegrationTests.Tests.StationRecords;
 

--- a/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/BluespacePulseOnTriggerSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared._Starlight.NullSpace;
 using Content.Shared._Starlight;
+using Content.Shared.Stacks;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -9,9 +10,10 @@ using Robust.Shared.Timing;
 namespace Content.Server._Starlight.NullSpace;
 
 /// <summary>
-/// Periodically scans for NullSpace entities within range and pulses to remove them + stun.
-/// Uses Update-based detection instead of TriggerOnProximity because NullSpace entities
-/// cancel all physics contacts, making physics-based proximity sensors blind to them.
+/// Flashers: periodically scan for NullSpace entities within range and pulse to remove + stun.
+/// Crystals: same effect but only on manual activation (TriggerOnUse/TriggerOnActivate).
+/// Update-based detection is used for flashers because NullSpace entities cancel physics contacts,
+/// making physics-based proximity sensors blind to them.
 /// </summary>
 public sealed class BluespacePulseOnTriggerSystem : EntitySystem
 {
@@ -20,8 +22,36 @@ public sealed class BluespacePulseOnTriggerSystem : EntitySystem
     [Dependency] private readonly TriggerSystem _trigger = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
+
+    private const string BluespaceFlasherId = "BluespaceFlasher";
+    private const string BluespaceCrystalId = "MaterialBluespace";
 
     private static readonly SoundPathSpecifier NullSpaceCutoffSound = new("/Audio/_HL/Effects/ma cutoff.ogg");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BluespacePulseOnTriggerComponent, TriggerEvent>(OnCrystalActivated);
+    }
+
+    private void OnCrystalActivated(Entity<BluespacePulseOnTriggerComponent> ent, ref TriggerEvent args)
+    {
+        if (MetaData(ent).EntityPrototype?.ID?.StartsWith(BluespaceCrystalId) != true)
+            return;
+
+        if (TryComp<StackComponent>(ent, out var stack))
+        {
+            _stack.Use(ent, 1, stack);
+            if (stack.Count <= 0)
+                QueueDel(ent);
+        }
+
+        // Do NOT call _trigger.Trigger(uid) here — TriggerOnUse/TriggerOnActivate already fired TriggerEvent
+        // to get us here, so calling Trigger again would cause infinite recursion.
+        DoPulse(ent, ent.Comp);
+        args.Handled = true;
+    }
 
     public override void Update(float frameTime)
     {
@@ -35,7 +65,12 @@ public sealed class BluespacePulseOnTriggerSystem : EntitySystem
             if (curTime < comp.NextTrigger)
                 continue;
 
-            // Collect NullSpace entities in range before modifying any components
+            if (MetaData(uid).EntityPrototype?.ID != BluespaceFlasherId)
+                continue;
+
+            if (!xform.Anchored)
+                continue;
+
             var found = new List<EntityUid>();
             foreach (var ent in _lookup.GetEntitiesInRange(uid, comp.Radius))
             {
@@ -47,19 +82,30 @@ public sealed class BluespacePulseOnTriggerSystem : EntitySystem
                 continue;
 
             comp.NextTrigger = curTime + comp.Cooldown;
-
-            // Fire effects (EmitSoundOnTrigger + SpawnOnTrigger)
             _trigger.Trigger(uid);
+            DoPulse(uid, comp, found);
+        }
+    }
 
-            // Remove NullSpace and stun all detected entities
-            var stunTime = TimeSpan.FromSeconds(comp.StunSeconds);
-            foreach (var ent in found)
+    private void DoPulse(EntityUid uid, BluespacePulseOnTriggerComponent comp, List<EntityUid>? preFound = null)
+    {
+        var found = preFound ?? new List<EntityUid>();
+        if (preFound == null)
+        {
+            foreach (var ent in _lookup.GetEntitiesInRange(uid, comp.Radius))
             {
-                if (HasComp<ShadekinComponent>(ent))
-                    _audio.PlayPvs(NullSpaceCutoffSound, ent);
-                RemComp<NullSpaceComponent>(ent);
-                _stun.TryParalyze(ent, stunTime, true);
+                if (HasComp<NullSpaceComponent>(ent))
+                    found.Add(ent);
             }
+        }
+
+        var stunTime = TimeSpan.FromSeconds(comp.StunSeconds);
+        foreach (var ent in found)
+        {
+            if (HasComp<ShadekinComponent>(ent))
+                _audio.PlayPvs(NullSpaceCutoffSound, ent);
+            RemComp<NullSpaceComponent>(ent);
+            _stun.TryParalyze(ent, stunTime, true);
         }
     }
 }

--- a/Content.Tests/Server/_HL/NullSpace/ShipSaveNullSpaceTest.cs
+++ b/Content.Tests/Server/_HL/NullSpace/ShipSaveNullSpaceTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
+#nullable enable
 
 namespace Content.Tests.Server._HL.NullSpace;
 


### PR DESCRIPTION
## About the PR + Why / Balance
Gunnery console doesn't pull people from nullspace -- unintended bug fixed.
Bluespace crystals are used one at a time on activation -- prevent spamming, use anchors for area denial.
Bluespace anchors need to be anchored to work -- prevent dragging around, use crystals + goggles for portable nullspace counteraction. Or just shoot them with lasers or disablers.

## Technical details
Split bluespace flashers and bluespace crystals triggering points, kept logic in the same place.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
