### PR TITLE
Port Starlight PR #2104

### DIFF
--- a/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Traits.Assorted; // Starlight-edit
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Eye.Blinding.Components;
@@ -42,4 +43,12 @@ public sealed partial class BlindableComponent : Component
     /// </description>
     [Access(Other = AccessPermissions.ReadWriteExecute)]
     public bool GraceFrame = false;
+
+    #region Starlight
+    [DataField, Access(typeof(PermanentBlindnessSystem), typeof(BlurryVisionSystem))]
+    public bool GlassesFixable = false;
+
+    [AutoNetworkedField, Access(typeof(PermanentBlindnessSystem), typeof(BlurryVisionSystem))]
+    public bool IsWearingGlasses = false;
+    #endregion
 }

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -24,7 +24,7 @@ public sealed class BlindableSystem : EntitySystem
 
     private void OnDamageChanged(Entity<BlindableComponent> ent, ref EyeDamageChangedEvent args)
     {
-        _blurriness.UpdateBlurMagnitude((ent.Owner, ent.Comp));
+        _blurriness.UpdateBlurMagnitude((ent.Owner, ent.Comp), ent.Comp.IsWearingGlasses); // Starlight-edit
         _eyelids.UpdateEyesClosable((ent.Owner, ent.Comp));
     }
 

--- a/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlurryVisionSystem.cs
@@ -21,7 +21,7 @@ public sealed class BlurryVisionSystem : EntitySystem
         args.Args.CorrectionPower *= glasses.Comp.CorrectionPower;
     }
 
-    public void UpdateBlurMagnitude(Entity<BlindableComponent?> ent)
+    public void UpdateBlurMagnitude(Entity<BlindableComponent?> ent, bool glasses) // starlight change: glasses param
     {
         if (!Resolve(ent.Owner, ref ent.Comp, false))
             return;
@@ -36,20 +36,21 @@ public sealed class BlurryVisionSystem : EntitySystem
             return;
         }
 
+        ent.Comp.IsWearingGlasses = glasses && ent.Comp.GlassesFixable; // Starlight-edit
         var blurry = EnsureComp<BlurryVisionComponent>(ent);
-        blurry.Magnitude = blur;
+        blurry.Magnitude = glasses && ent.Comp.GlassesFixable ? 0 : blur; // starlight
         blurry.CorrectionPower = ev.CorrectionPower;
         Dirty(ent, blurry);
     }
 
     private void OnGlassesEquipped(Entity<VisionCorrectionComponent> glasses, ref GotEquippedEvent args)
     {
-        UpdateBlurMagnitude(args.Equipee);
+        UpdateBlurMagnitude(args.Equipee, true); // starlight change: glasses param
     }
 
     private void OnGlassesUnequipped(Entity<VisionCorrectionComponent> glasses, ref GotUnequippedEvent args)
     {
-        UpdateBlurMagnitude(args.Equipee);
+        UpdateBlurMagnitude(args.Equipee, false); // starlight change: glasses param
     }
 }
 

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessComponent.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessComponent.cs
@@ -13,5 +13,8 @@ public sealed partial class PermanentBlindnessComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public int Blindness = 0;
+    
+    [DataField, AutoNetworkedField] 
+    public bool GlassesFixable = false; // starlight
 }
 

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -45,6 +45,8 @@ public sealed class PermanentBlindnessSystem : EntitySystem
         if(!TryComp<BlindableComponent>(blindness.Owner, out var blindable))
             return;
 
+        blindable.GlassesFixable = blindness.Comp.GlassesFixable; // starlight
+
         if (blindness.Comp.Blindness != 0)
             _blinding.SetMinDamage((blindness.Owner, blindable), blindness.Comp.Blindness);
         else

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -26,6 +26,7 @@
   components:
     - type: PermanentBlindness
       blindness: 4
+      glassesFixable: true # Starlight-edit
 
 - type: trait
   id: Narcolepsy


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes glasses to actually, properly, completely correct shortsighted vision (but not regular welding damage).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Right now, short-sightedness trait is effectively welding blindness, and glasses don't fully fix that. Which is very annoying for this specific use case...
This changes that without affecting regular eye damage with a new datafield, `GlassesFixable` (and an internal field `IsWearingGlasses`).

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- tweak: Glasses now properly fix short-sightedness.
