### PR TITLE
Add delay on foxfires

### DIFF
--- a/Resources/Prototypes/_DV/Actions/kitsune.yml
+++ b/Resources/Prototypes/_DV/Actions/kitsune.yml
@@ -6,6 +6,7 @@
   - type: InstantAction
     charges: 3
     disableWhenEmpty: false
+    useDelay: 5
     icon: { sprite: _DV/Structures/Specific/Species/Kitsune/foxfire.rsi, state: icon }
     event: !type:CreateFoxfireActionEvent
 


### PR DESCRIPTION

## About the PR
Add 5 seconds delay to foxfires -- that allows to create a stack of maximum 6 foxfires.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Spamming foxfires is uncontrollable entity creation, breaks ability convention (having at least some delay, e.g. on aphro bite) and is extremely harmful to any light-sensitive entity.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
