### PR TITLE
fix UI screen to process over-cap, required traits and dependent traits

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -792,6 +792,24 @@ namespace Content.Client.Lobby.UI
                                 tooltipParts.Add($"You must not be: {string.Join(", ", names)}");
                         }
 
+                        foreach (var requirement in trait.Requirements)
+                        {
+                            if (requirement is TraitsRequirement traitsReq)
+                            {
+                                var names = new List<string>();
+                                foreach (var reqId in traitsReq.Traits)
+                                {
+                                    if (_prototypeManager.TryIndex(reqId, out var reqProto))
+                                        names.Add($"[color=#FFD700]{Loc.GetString(reqProto.Name)}[/color]");
+                                }
+                                if (names.Count > 0)
+                                {
+                                    var label = traitsReq.Inverted ? "Must not have" : "Requires one of";
+                                    tooltipParts.Add($"{label}: {string.Join(", ", names)}");
+                                }
+                            }
+                        }
+
                         if (tooltipParts.Count > 0)
                             selector.SetTooltip(string.Join("\n", tooltipParts));
                     }
@@ -838,11 +856,13 @@ namespace Content.Client.Lobby.UI
                         else
                         {
                             Profile = Profile?.WithoutTraitPreference(trait.ID, _prototypeManager);
+                            Profile = RemoveCascadedInvalidTraits(Profile);
+                            SetDirty();
+                            RefreshTraits();
+                            return;
                         }
 
                         SetDirty();
-
-                        UpdateTraitIncompatibilityVisibility(allSelectors);
 
                         // Instead of refreshing the entire UI, just update the point counter if needed
                         if (category is { MaxTraitPoints: >= 0 })
@@ -900,6 +920,9 @@ namespace Content.Client.Lobby.UI
                             // Update all trait colors based on the new point total
                             RefreshTraitColors(categoryButton, category, currentPoints);
                         }
+
+                        // Must run after RefreshTraitColors so requirement-based gray-out isn't overridden.
+                        UpdateTraitIncompatibilityVisibility(allSelectors);
                     };
                     selectors.Add(selector);
                 }
@@ -1008,14 +1031,17 @@ namespace Content.Client.Lobby.UI
         {
             var selected = Profile?.TraitPreferences ?? new HashSet<ProtoId<TraitPrototype>>();
             var currentSpecies = Profile?.Species;
+            IReadOnlyDictionary<string, TimeSpan> emptyPlayTimes = new Dictionary<string, TimeSpan>();
 
             foreach (var (traitId, selector) in allSelectors)
             {
                 var hide = false;
+                var unavailable = false;
 
                 if (selected.Contains(traitId))
                 {
                     selector.Visible = true;
+                    selector.SetUnavailable(false);
                     continue;
                 }
 
@@ -1029,9 +1055,14 @@ namespace Content.Client.Lobby.UI
                 {
                     ProtoId<SpeciesPrototype> speciesId = currentSpecies.Value;
                     if (thisProto.SpeciesBlacklist.Contains(speciesId))
-                    {
                         hide = true;
-                    }
+                }
+
+                // Whitelist check: uses the preview dummy entity which carries species components.
+                if (!hide && thisProto.Whitelist != null && _entManager.EntityExists(PreviewDummy))
+                {
+                    if (_whitelist.IsWhitelistFail(thisProto.Whitelist, PreviewDummy))
+                        hide = true;
                 }
 
                 if (!hide)
@@ -1049,8 +1080,103 @@ namespace Content.Client.Lobby.UI
                     }
                 }
 
+                // Requirements check: gray out traits whose prerequisites aren't yet selected.
+                if (!hide && thisProto.Requirements.Count > 0)
+                {
+                    foreach (var requirement in thisProto.Requirements)
+                    {
+                        if (!requirement.Check(_entManager, _prototypeManager, Profile, emptyPlayTimes, out _))
+                        {
+                            unavailable = true;
+                            break;
+                        }
+                    }
+                }
+
                 selector.Visible = !hide;
+                selector.SetUnavailable(unavailable);
             }
+        }
+
+        /// Removes any selected traits whose Requirements are no longer satisfied, then enforces per-category
+        /// point budgets by dropping the most expensive positive-cost trait until within limits.
+        private HumanoidCharacterProfile? RemoveCascadedInvalidTraits(HumanoidCharacterProfile? profile)
+        {
+            if (profile == null)
+                return null;
+
+            IReadOnlyDictionary<string, TimeSpan> emptyPlayTimes = new Dictionary<string, TimeSpan>();
+
+            // Repeat until stable: remove any selected trait whose requirements are now unmet.
+            bool anyRemoved;
+            do
+            {
+                anyRemoved = false;
+                foreach (var traitId in profile.TraitPreferences.ToList())
+                {
+                    if (!_prototypeManager.TryIndex<TraitPrototype>(traitId, out var traitProto))
+                        continue;
+
+                    var failed = false;
+                    foreach (var requirement in traitProto.Requirements)
+                    {
+                        if (!requirement.Check(_entManager, _prototypeManager, profile, emptyPlayTimes, out _))
+                        {
+                            failed = true;
+                            break;
+                        }
+                    }
+
+                    if (!failed)
+                        continue;
+
+                    profile = profile.WithoutTraitPreference(traitId, _prototypeManager);
+                    anyRemoved = true;
+                    break; // restart — TraitPreferences snapshot is stale
+                }
+            } while (anyRemoved);
+
+            // Safety: enforce per-category budget by removing the most expensive positive-cost trait.
+            var categorySpend = new Dictionary<ProtoId<TraitCategoryPrototype>, int>();
+            foreach (var traitId in profile.TraitPreferences)
+            {
+                if (!_prototypeManager.TryIndex<TraitPrototype>(traitId, out var p) || p.Category == null)
+                    continue;
+                var catId = p.Category.Value;
+                categorySpend.TryGetValue(catId, out var cur);
+                categorySpend[catId] = cur + p.Cost;
+            }
+
+            foreach (var (catId, spent) in categorySpend)
+            {
+                if (!_prototypeManager.TryIndex<TraitCategoryPrototype>(catId, out var categoryProto))
+                    continue;
+                if (categoryProto.MaxTraitPoints is not { } maxPoints || spent <= maxPoints)
+                    continue;
+
+                var remaining = spent;
+                while (remaining > maxPoints)
+                {
+                    TraitPrototype? mostExpensive = null;
+                    foreach (var traitId in profile.TraitPreferences)
+                    {
+                        if (!_prototypeManager.TryIndex<TraitPrototype>(traitId, out var p))
+                            continue;
+                        if (p.Category != catId || p.Cost <= 0)
+                            continue;
+                        if (mostExpensive == null || p.Cost > mostExpensive.Cost)
+                            mostExpensive = p;
+                    }
+
+                    if (mostExpensive == null)
+                        break;
+
+                    remaining -= mostExpensive.Cost;
+                    profile = profile.WithoutTraitPreference(mostExpensive.ID, _prototypeManager);
+                }
+            }
+
+            return profile;
         }
 
         /// <summary>


### PR DESCRIPTION

## About the PR
We currently have traits which depends on comps and traits which depend on traits -- but that isn't reflected in the char UI. Fixed now.
Also, fixed a bug when selecting traits in certain order allowed for negative traits values (e.g. start with +10 points, select pacifist (+10) -- select platelets (-10) -- select heatproof (-10) -- delesect pacifist: now player has -10 points but still can play the character) -- now it's deleting most expensive traits until the points are non-negative
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Bugfixes
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
