### PR TITLE
Medical bounty event

### DIFF
--- a/Content.Server/StationEvents/Components/MedicalBountyTargetsRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/MedicalBountyTargetsRuleComponent.cs
@@ -1,0 +1,17 @@
+using Content.Server.StationEvents.Events;
+using Content.Shared.Storage;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(MedicalBountyTargetsRule))]
+public sealed partial class MedicalBountyTargetsRuleComponent : Component
+{
+    [DataField("entries")]
+    public List<EntitySpawnEntry> Entries = new();
+
+    [DataField("departmentId")]
+    public string DepartmentId = "Medical";
+
+    [DataField("variance")]
+    public float Variance = 0.1f;
+}

--- a/Content.Server/StationEvents/Events/MedicalBountyTargetsRule.cs
+++ b/Content.Server/StationEvents/Events/MedicalBountyTargetsRule.cs
@@ -1,0 +1,97 @@
+using Content.Server.StationEvents.Components;
+using Content.Shared._HL.Rescue.Rescue;
+using Content.Shared._NF.Roles.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using Content.Shared.Station.Components;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class MedicalBountyTargetsRule : StationEventSystem<MedicalBountyTargetsRuleComponent>
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    protected override void Started(EntityUid uid, MedicalBountyTargetsRuleComponent component, GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var station)
+            || component.Entries.Count == 0
+            || !PrototypeManager.TryIndex<DepartmentPrototype>(component.DepartmentId, out var department))
+        {
+            return;
+        }
+
+        var beacons = GetStationRescueBeacons(station.Value);
+        if (beacons.Count == 0)
+            return;
+
+        var medicalWorkers = CountDepartmentWorkers(station.Value, department);
+        if (medicalWorkers <= 0)
+            return;
+
+        var variation = RobustRandom.NextFloat(-component.Variance, component.Variance);
+        var spawnCount = Math.Max(1, (int) MathF.Round(medicalWorkers * (1f + variation)));
+
+        for (var i = 0; i < spawnCount; i++)
+        {
+            var beacon = RobustRandom.Pick(beacons);
+            var entry = RobustRandom.Pick(component.Entries);
+            Spawn(entry.PrototypeId, beacon);
+        }
+    }
+
+    private int CountDepartmentWorkers(EntityUid station, DepartmentPrototype department)
+    {
+        var roles = department.Roles;
+        var count = 0;
+
+        var query = EntityQueryEnumerator<JobTrackingComponent, MindContainerComponent>();
+        while (query.MoveNext(out _, out var tracking, out var mindContainer))
+        {
+            if (!tracking.Active
+                || tracking.SpawnStation != station
+                || tracking.Job is not { } jobId
+                || !roles.Contains(jobId))
+            {
+                continue;
+            }
+
+            if (!mindContainer.HasMind
+                || !TryComp<MindComponent>(mindContainer.Mind, out var mind)
+                || mind.UserId is not { } userId
+                || !_player.TryGetSessionById(userId, out var session)
+                || session.Status != SessionStatus.InGame)
+            {
+                continue;
+            }
+
+            count++;
+        }
+
+        return count;
+    }
+
+    private List<EntityCoordinates> GetStationRescueBeacons(EntityUid station)
+    {
+        var beacons = new List<EntityCoordinates>();
+        var query = EntityQueryEnumerator<RescueBeaconComponent, TransformComponent>();
+        while (query.MoveNext(out _, out _, out var transform))
+        {
+            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station != station)
+                continue;
+
+            beacons.Add(transform.Coordinates);
+        }
+
+        return beacons;
+    }
+}

--- a/Resources/Locale/en-US/station-events/events/medical-bounty-targets.ftl
+++ b/Resources/Locale/en-US/station-events/events/medical-bounty-targets.ftl
@@ -1,0 +1,1 @@
+station-event-medical-bounty-targets-start-announcement= Attention. We have detected a distress signal from a nearby shuttle and are preparing extraction of shuttle personnel. Stationside medical personnel is advised to prepare for triage at the medical rescue beacon.

--- a/Resources/Prototypes/_HL/GameRules/events.yml
+++ b/Resources/Prototypes/_HL/GameRules/events.yml
@@ -84,6 +84,7 @@
     - id: reagentslimeVents
     - id: SpaceVents
     - id: CarpVents
+    - id: MedicalBountyTargetsSpawn
     - id: TickVents
     - id: AiVents
     - id: LizardVents
@@ -1692,6 +1693,41 @@
       prob: 0.01
 
 - type: entity
+  id: MedicalBountyTargetsSpawn
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-medical-bounty-targets-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 20
+    reoccurrenceDelay: 180
+    minimumPlayers: 15
+    weight: 5
+    duration: 1
+  - type: MedicalBountyTargetsRule
+    departmentId: Medical
+    variance: 0.1
+    entries:
+    - id: SpawnRandomHumanoidCorpseMedicalBounty
+      prob: 0.02
+    - id: SpawnRandomHumanoidCorpseMedicalBountyService
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountyEngineering
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountyCargo
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountyMedical
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountyScience
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountySecurity
+      prob: 0.015
+    - id: SpawnRandomHumanoidCorpseMedicalBountyCommand
+      prob: 0.01
+
+- type: entity
   id: CarpVents
   parent: [VentCrittersBase, BaseGameRule]
   categories: [ HideSpawnMenu ]
@@ -2225,3 +2261,6 @@
     checkInterval: 600  # Check every 10 minutes (600 seconds)
     mercenaryJob: Mercenary
     mercenaryCap: 40  # Maximum slots
+
+
+

--- a/Resources/Prototypes/_NF/Catalog/Bounties/medical_bounties.yml
+++ b/Resources/Prototypes/_NF/Catalog/Bounties/medical_bounties.yml
@@ -12,7 +12,7 @@
       max: 200
       value: 10
       penalty: 10
-  baseReward: 2000 # 4K-8K
+  baseReward: 6000 # 4K-8K
 
 - type: medicalBounty
   id: MurderedPierce
@@ -27,7 +27,7 @@
       max: 200
       value: 10
       penalty: 10
-  baseReward: 2000 # 4K-8K
+  baseReward: 6000 # 4K-8K
 
 - type: medicalBounty
   id: MurderedSlash
@@ -42,7 +42,7 @@
       max: 200
       value: 10
       penalty: 10
-  baseReward: 2000 # 4K-8K
+  baseReward: 6000 # 4K-8K
 
 - type: medicalBounty
   id: MildBruteMix
@@ -67,7 +67,7 @@
       max: 150
       value: 10
       penalty: 10
-  baseReward: 2000 # 5K-8K
+  baseReward: 6000 # 5K-8K
 
 - type: medicalBounty
   id: Suffocated
@@ -82,7 +82,7 @@
       max: 200
       value: 10
       penalty: 10
-  baseReward: 2000 # 4K-8K
+  baseReward: 6000 # 4K-8K
 
 - type: medicalBounty
   id: PlasmaFire
@@ -92,7 +92,7 @@
       max: 3000
       value: 10
       penalty: 10
-  baseReward: 2000 # 10K-32K
+  baseReward: 15000 # 10K-32K
 
 - type: medicalBounty
   id: Spaced
@@ -117,7 +117,7 @@
       max: 2000
       value: 10
       penalty: 10
-  baseReward: 1000 # 8500-24K
+  baseReward: 10000 # 8500-24K
 
 - type: medicalBounty
   id: MildBurnMix
@@ -142,7 +142,7 @@
       max: 150
       value: 10
       penalty: 10
-  baseReward: 2000 # 4K-8K
+  baseReward: 6000 # 4K-8K
 
 - type: medicalBounty
   id: Insuls
@@ -157,7 +157,7 @@
       max: 600
       value: 10
       penalty: 10
-  baseReward: 1500 # 7500-11500
+  baseReward: 8500 # 7500-11500
 
 - type: medicalBounty
   id: AcidSlimes
@@ -167,7 +167,7 @@
       max: 500
       value: 20
       penalty: 20
-  baseReward: 2000 # 8K-12K
+  baseReward: 10000 # 8K-12K
 
 - type: medicalBounty
   id: SpiderAttackMild
@@ -187,7 +187,7 @@
       min: 30
       max: 50
       value: 20
-  baseReward: 3500 # 6600-10500
+  baseReward: 8000 # 6600-10500
 
 - type: medicalBounty
   id: SpiderAttack
@@ -202,7 +202,7 @@
       min: 30
       max: 50
       value: 20
-  baseReward: 3500 # 7100-10500
+  baseReward: 9000 # 7100-10500
 
 - type: medicalBounty
   id: DeliciousMushroom
@@ -222,7 +222,7 @@
       min: 30
       max: 50
       value: 30
-  baseReward: 3000 # 6400-10500
+  baseReward: 6000 # 6400-10500
 
 - type: medicalBounty
   id: HyperpacmanGoneWrong
@@ -242,7 +242,7 @@
       max: 200
       value: 10
       penalty: 10
-  baseReward: 1500 # ~6250-19K
+  baseReward: 18000 # ~6250-19K
 
 - type: medicalBounty
   id: AsphyxAndCellular
@@ -257,7 +257,7 @@
       max: 140
       value: 25
       penalty: 25
-  baseReward: 2000 # 5500-9500
+  baseReward: 8000 # 5500-9500
 
 - type: medicalBounty
   id: DeliciousUranium
@@ -286,4 +286,4 @@
       min: 30
       max: 50
       value: 25
-  baseReward: 1500 # 5300-13500
+  baseReward: 7500 # 5300-13500


### PR DESCRIPTION

## About the PR
I added a new gamerule that automatically spawns medical bounty targets at the rescue beacon. 
The amount of bounty targets is dependent on the amount of registered medical personnel on station.
I also adjusted the amount of payout a medical bounty provides. 

## Why / Balance
This event is the first part of my planned rework of the medical department with the intention to make work in the medical department more engaging. 

## Technical details
When the event triggers it checks for the amount of medical personnel in the department and spawns an amount of medical targets equal to the amount of medical personnel +- 10% at the rescue beacon.

## How to test
* spawn in as medical personnel
* addgamerule MedicalBountyTargetsSpawn

## Media
<img width="1649" height="746" alt="image" src="https://github.com/user-attachments/assets/cfcb9dba-9317-449d-9ec4-6cd211d51252" />


**Changelog**

:cl:
- add: added new medical bounty target event 
- tweak: Increased payout of medical bounty targets

