### PR TITLE
Hydroponics Tritium & Frezon Clamp

### DIFF
--- a/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMutateGases.cs
@@ -50,6 +50,11 @@ public sealed partial class PlantMutateExudeGasses : EntityEffect
         if (gasses.ContainsKey(gas))
         {
             gasses[gas] += amount;
+            if ((gas==Gas.Tritium) || (gas==Gas.Frezon))
+            {
+                 if (gasses[gas]>MaxValue)
+                    {gasses[gas]=MaxValue;}
+            }
         }
         else
         {
@@ -105,6 +110,11 @@ public sealed partial class PlantMutateConsumeGasses : EntityEffect
         if (gasses.ContainsKey(gas))
         {
             gasses[gas] += amount;
+            if ((gas==Gas.Tritium) || (gas==Gas.Frezon))
+            {
+                 if (gasses[gas]>MaxValue)
+                    {gasses[gas]=MaxValue;}
+            }
         }
         else
         {


### PR DESCRIPTION
## About the PR
Currently if a plant mutates a gas that it already produces or consumes the new gas production or consumption is added to the old gas production or consumption. This allows for excessive tritium and/or frezon production from a single plant. This PR makes it so the total production and consumption of tritium or frezon cannot exceed that which is possible for a single mutation. This change does not affect other gasses.

## Balance
Currently "MaxValue" is set to 0.5 and is used elsewhere in the code to set the maximum random number that can be added to gas production or consumption. This PR's code can be changed to a different value if further balance is needed.