### PR TITLE
Reintroduced vending machine items for expeditions.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
@@ -476,15 +476,18 @@
     - VendingMachinePottedPlantVend
     - WaterCooler
     - SpawnDungeonMachineFrame
-    #- VendingMachineChang # No food vendomats in expeds - buy from food ships or die
-    #- VendingMachineDonut
-    #- VendingMachineDiscount
-    #- VendingMachineSnack
-    #- VendingMachineSustenance
-    #- VendingMachineSnackBlue
-    #- VendingMachineSnackOrange
-    #- VendingMachineSnackGreen
-    #- VendingMachineSnackTeal
+    # HL Vendor Change Start - expeds should have snack machines
+    # No food vendomats in expeds - buy from food ships or die
+    - VendingMachineChang 
+    - VendingMachineDonut
+    - VendingMachineDiscount
+    - VendingMachineSnack
+    - VendingMachineSustenance
+    - VendingMachineSnackBlue
+    - VendingMachineSnackOrange
+    - VendingMachineSnackGreen
+    - VendingMachineSnackTeal
+    # HL Vendor Change End
     chance: 1
     offset: 0.0
     rarePrototypes:


### PR DESCRIPTION
Reintroduced vending machine items for expeditions.



## About the PR
Uncommented Snack Vendors from the dungeon spawn pool

## Why / Balance
Ships lack snacks for when you want chocolate or chips for your rec area, this puts them back in rotation for expeditions, meaning everyone can have snacks now!

## Technical details
Uncommented Snack Vendors from the dungeon spawn pool

## How to test
Snack machines now show up on expeditions together with all the other vendors.

:cl:
- add: Added snack vending machines back to the expedition spawn pool!
