### PR TITLE
Add Visibility Toggle for Unique Cyborg Subtype Sprites

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -32,6 +32,7 @@
                 <!-- Misc -->
                 <Label Text="{Loc 'ui-options-misc-label'}" StyleClasses="LabelKeyText"/>
                 <CheckBox Name="FpsCounterCheckBox" Text="{Loc 'ui-options-fps-counter'}" />
+                <CheckBox Name="ShowCyborgSubtypesCheckBox" Text="{Loc 'ui-options-show-cyborg-subtypes'}" />
             </BoxContainer>
         </ScrollContainer>
         <ui:OptionsTabControlRow Name="Control" Access="Public" />

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -61,6 +61,7 @@ public sealed partial class GraphicsTab : Control
         Control.AddOptionCheckBox(CCVars.ViewportScaleRender, ViewportLowResCheckBox, invert: true);
         Control.AddOptionCheckBox(CCVars.ParallaxLowQuality, ParallaxLowQualityCheckBox);
         Control.AddOptionCheckBox(CCVars.HudFpsCounterVisible, FpsCounterCheckBox);
+        Control.AddOptionCheckBox(CCVars.ShowCyborgSubtypeSprites, ShowCyborgSubtypesCheckBox); // HardLight
 
         Control.Initialize();
 

--- a/Content.Client/_CD/Silicons/Borgs/BorgSwitchableSubtypeSystem.cs
+++ b/Content.Client/_CD/Silicons/Borgs/BorgSwitchableSubtypeSystem.cs
@@ -2,11 +2,13 @@ using System.Linq;
 using Content.Client.Silicons.Borgs;
 using Content.Shared._CD.Silicons;
 using Content.Shared._CD.Silicons.Borgs;
+using Content.Shared.CCVar; // HardLight
 using Content.Shared.Movement.Components;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.Configuration; // HardLight
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Utility;
@@ -23,6 +25,7 @@ public sealed class BorgSwitchableSubtypeSystem : SharedBorgSwitchableSubtypeSys
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
     [Dependency] private readonly FixtureSystem _fixture = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // HardLight
 
     public override void Initialize()
     {
@@ -44,6 +47,13 @@ public sealed class BorgSwitchableSubtypeSystem : SharedBorgSwitchableSubtypeSys
 
     protected override void UpdateEntityAppearance(Entity<BorgSwitchableSubtypeComponent> entity, BorgSubtypePrototype borgSubtypePrototype)
     {
+        // HardLight: Check if player has disabled custom borg sprites
+        if (!_cfg.GetCVar(CCVars.ShowCyborgSubtypeSprites))
+        {
+            // Don't apply custom appearance for remote entities
+            return;
+        }
+
         // LOT of copy pasted code from BorgSwitchableTypeSystem, but is probably necessary unless the upstream code
         // is refactored
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -255,5 +255,11 @@ public sealed partial class CCVars : CVars
 
     #endregion
 
+    /// <summary>
+    /// HardLight: Whether to show custom borg subtype sprites, or render all borgs with their base chassis sprites.
+    /// </summary>
+    public static readonly CVarDef<bool> ShowCyborgSubtypeSprites =
+        CVarDef.Create("display.show_cyborg_subtypes", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
 }
 #endregion

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -109,6 +109,7 @@ ui-options-vp-low-res = Low-resolution viewport
 ui-options-parallax-low-quality = Low-quality Parallax (background)
 ui-options-ambient-occlusion = Show Ambient Occlusion
 ui-options-fps-counter = Show FPS counter
+ui-options-show-cyborg-subtypes = Show unique Cyborg subtype sprites
 ui-options-vp-width = Viewport width:
 ui-options-hud-layout = HUD layout:
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Does as it says in the title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Many of the unique sprites that came with the selectable Cyborg types PR are, to be polite, hideous. 

I'm sure I'm not the only one that doesn't want to see them, and I'm using that as an excuse for making a means for me to NEVER have to see them. 

## Technical details
<!-- Summary of code changes for easier review. -->
Client-side toggle in the Graphics tab under Misc that, if toggled off, prevents the visibility of all unique sprites for Cyborgs. Cyborgs will instead appear as the default sprite for whatever chassis type they have selected.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn a Cyborg. Select a type and unique subtype. Open the Graphics settings. Uncheck the "Show unique Cyborg subtype sprites" option under Misc. Relog. Observe that the Cyborg now appears as the default sprite for whatever category of chassis selected.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
OUUGH, MY LEG.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The visibility of unique Cyborg subtype sprites may now be toggled on/off (on by default) in user Graphics settings.
