### PR TITLE
Fix Displacements Failing to Render for Spray Painted Clothing

### DIFF
--- a/Content.Client/Paint/PaintVisualizerSystem.cs
+++ b/Content.Client/Paint/PaintVisualizerSystem.cs
@@ -11,6 +11,10 @@ namespace Content.Client.Paint
 {
     public sealed class PaintedVisualizerSystem : VisualizerSystem<PaintedComponent>
     {
+        private const string GreyscaleShader = "Greyscale"; // HardLight
+        private const string DisplacedStencilDrawShader = "DisplacedStencilDraw"; // HardLight
+        private const string DisplacedGreyscaleShader = "DisplacedGreyscale"; // HardLight
+
         /// <summary>
         /// Visualizer for Paint which applies a shader and colors the entity.
         /// </summary>
@@ -67,10 +71,12 @@ namespace Content.Client.Paint
 
             foreach (var revealed in args.RevealedLayers)
             {
-                if (!_sprite.LayerMapTryGet((args.User, sprite), revealed, out var layer, false) || sprite[layer] is not Layer notlayer)
+                if (!_sprite.LayerMapTryGet((args.User, sprite), revealed, out var layer, false) || // HardLight
+                    sprite[layer] is not Layer spriteLayer || // Added spriteLayer
+                    spriteLayer.CopyToShaderParameters != null)
                     continue;
 
-                sprite.LayerSetShader(layer, component.ShaderName);
+                sprite.LayerSetShader(layer, GetPaintShaderPrototype(component.ShaderName, spriteLayer)); // HardLight: Added GetPaintShaderPrototype & spriteLayer
                 _sprite.LayerSetColor((args.User, sprite), layer, component.Color);
             }
         }
@@ -85,12 +91,24 @@ namespace Content.Client.Paint
 
             foreach (var revealed in args.RevealedLayers)
             {
-                if (!_sprite.LayerMapTryGet((args.Equipee, sprite), revealed, out var layer, false) || sprite[layer] is not Layer notlayer)
+                if (!_sprite.LayerMapTryGet((args.Equipee, sprite), revealed, out var layer, false) || // HardLight
+                    sprite[layer] is not Layer spriteLayer || // Added spriteLayer
+                    spriteLayer.CopyToShaderParameters != null)
                     continue;
 
-                sprite.LayerSetShader(layer, component.ShaderName);
+                sprite.LayerSetShader(layer, GetPaintShaderPrototype(component.ShaderName, spriteLayer)); // HardLight: Added GetPaintShaderPrototype & spriteLayer
                 _sprite.LayerSetColor((args.Equipee, sprite), layer, component.Color);
             }
+        }
+
+        // HardLight: Preserve displacement-aware clothing rendering by using a combined shader
+        // instead of replacing the displacement shader with plain greyscale paint.
+        private static string GetPaintShaderPrototype(string defaultShader, Layer layer)
+        {
+            if (defaultShader == GreyscaleShader && layer.ShaderPrototype == DisplacedStencilDrawShader)
+                return DisplacedGreyscaleShader;
+
+            return defaultShader;
         }
 
         private void OnShutdown(EntityUid uid, PaintedComponent component, ref ComponentShutdown args)

--- a/Resources/Prototypes/_HL/Shaders/displacement.yml
+++ b/Resources/Prototypes/_HL/Shaders/displacement.yml
@@ -1,0 +1,6 @@
+- type: shader
+  id: DisplacedGreyscale
+  kind: source
+  path: "/Textures/_HL/Shaders/displaced_greyscale.swsl"
+  params:
+    displacementSize: 127

--- a/Resources/Textures/_HL/Shaders/displaced_greyscale.swsl
+++ b/Resources/Textures/_HL/Shaders/displaced_greyscale.swsl
@@ -1,0 +1,17 @@
+uniform sampler2D displacementMap;
+uniform highp float displacementSize;
+uniform highp vec4 displacementUV;
+
+varying highp vec2 displacementUVOut;
+
+void vertex() {
+    displacementUVOut = mix(displacementUV.xy, displacementUV.zw, tCoord2);
+}
+
+void fragment() {
+    highp vec4 displacementSample = texture2D(displacementMap, displacementUVOut);
+    highp vec2 displacementValue = (displacementSample.xy - vec2(128.0 / 255.0)) / (1.0 - 128.0 / 255.0);
+    highp vec4 color = zTexture(UV + displacementValue * TEXTURE_PIXEL_SIZE * displacementSize * vec2(1.0, -1.0));
+
+    COLOR = vec4(vec3(zGrayscale(color.rgb)), color.a * displacementSample.a);
+}


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Previously, clothes stopped rendering with displacements when spray painted, meaning if characters wanted to look like not a freak of nature, they had to forego personalization and wear default appearance equipment. Unfortunately, default appearance equipment sucks. Not really, but also really.

Now, clothes render with displacements regardless of painted state. 

You can finally live your fashionista lives and look slightly less horrible while doing it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because it was stupid. And now it's slightly less stupid.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new combined shader for spray-painted clothing that preserves species/body-type displacement while applying the paint recolor. I also updated the paint visualizer to use that shader on displaced worn clothing layers instead of replacing the displacement shader with plain greyscale.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
 You know, I feel like I don't need to explain this one, actually.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="888" height="430" alt="image" src="https://github.com/user-attachments/assets/44d9028c-56d1-45b9-89a8-a5c802f9f7bf" />
<img width="948" height="464" alt="image" src="https://github.com/user-attachments/assets/4aac0428-d3c6-43f6-8164-0d1e0561ee32" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
NanoTrasen's fashion sense. Specifically, their lack thereof. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Species displacements are no longer broken by applying spray paint to clothes/equipment/gear.
