### PR TITLE
Make Cyborg Subtype Sprite Visibility Update w/o Relog

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._CD.Silicons.Borgs;
+﻿using System.Linq; // HardLight
+using Content.Shared._CD.Silicons.Borgs;
 using Content.Shared.Movement.Components;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
@@ -38,13 +39,30 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         UpdateEntityAppearance(ent);
     }
 
+    public void RefreshEntityAppearance(Entity<BorgSwitchableTypeComponent> entity, bool ignoreSubtype = false) // HardLight
+    {
+        if (!Prototypes.TryIndex(entity.Comp.SelectedBorgType, out var prototype))
+            return;
+
+        ApplyEntityAppearance(entity, prototype, ignoreSubtype);
+    }
+
     protected override void UpdateEntityAppearance(
         Entity<BorgSwitchableTypeComponent> entity,
         BorgTypePrototype prototype)
     {
+        ApplyEntityAppearance(entity, prototype, false); // HardLight
+    }
+
+    private void ApplyEntityAppearance( // HardLight
+        Entity<BorgSwitchableTypeComponent> entity,
+        BorgTypePrototype prototype,
+        bool ignoreSubtype)
+    {
         // CD - added checks to stop sprite state errors
-        if (!TryComp<BorgSwitchableSubtypeComponent>(entity, out var subtype) ||
-            subtype.BorgSubtype != null)
+        if (!ignoreSubtype && // HardLight
+            (!TryComp<BorgSwitchableSubtypeComponent>(entity, out var subtype) || // HardLight
+             subtype.BorgSubtype != null))
             return;
 
         if (TryComp(entity, out SpriteComponent? sprite))
@@ -55,6 +73,10 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
             {
                 sprite.BaseRSI = res.RSI;
             }
+
+            if (ignoreSubtype) // HardLight
+                ResetBaseLayers((entity, sprite), prototype);
+
             _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.Body, prototype.SpriteBodyState);
             _sprite.LayerSetRsiState((entity, sprite), BorgVisualLayers.LightStatus, prototype.SpriteToggleLightState);
         }
@@ -93,5 +115,33 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         }
 
         base.UpdateEntityAppearance(entity, prototype);
+    }
+
+    // HardLight: Rebuild the default chassis layer stack so subtype sprites can revert cleanly at runtime.
+    private void ResetBaseLayers(Entity<SpriteComponent?> sprite, BorgTypePrototype prototype)
+    {
+        var spriteComp = sprite.Comp;
+        if (spriteComp == null)
+            return;
+
+        for (var i = spriteComp.AllLayers.Count() - 1; i >= 0; i--)
+        {
+            _sprite.RemoveLayer(sprite, i);
+        }
+
+        var body = _sprite.AddRsiLayer(sprite, prototype.SpriteBodyState);
+        _sprite.LayerMapSet(sprite, BorgVisualLayers.Body, body);
+        _sprite.LayerMapSet(sprite, "movement", body);
+
+        var light = _sprite.AddRsiLayer(sprite, prototype.SpriteNoMindState);
+        _sprite.LayerMapSet(sprite, BorgVisualLayers.Light, light);
+        spriteComp.LayerSetShader(light, "unshaded");
+        _sprite.LayerSetVisible(sprite, light, false);
+
+        var lightStatus = _sprite.AddRsiLayer(sprite, prototype.SpriteToggleLightState);
+        _sprite.LayerMapSet(sprite, BorgVisualLayers.LightStatus, lightStatus);
+        _sprite.LayerMapSet(sprite, "light", lightStatus);
+        spriteComp.LayerSetShader(lightStatus, "unshaded");
+        _sprite.LayerSetVisible(sprite, lightStatus, false);
     }
 }

--- a/Content.Client/_CD/Silicons/Borgs/BorgSwitchableSubtypeSystem.cs
+++ b/Content.Client/_CD/Silicons/Borgs/BorgSwitchableSubtypeSystem.cs
@@ -7,11 +7,8 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
-using Robust.Client.ResourceManagement;
 using Robust.Shared.Configuration; // HardLight
-using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
-using Robust.Shared.Utility;
 
 namespace Content.Client._CD.Silicons.Borgs;
 
@@ -22,17 +19,26 @@ public sealed class BorgSwitchableSubtypeSystem : SharedBorgSwitchableSubtypeSys
 {
     [Dependency] private readonly SpriteSystem _sprite = default!;
     [Dependency] private readonly BorgSystem _borg = default!;
+    [Dependency] private readonly BorgSwitchableTypeSystem _borgTypeSystem = default!; // HardLight
     [Dependency] private readonly AppearanceSystem _appearance = default!;
-    [Dependency] private readonly IResourceCache _resourceCache = default!;
-    [Dependency] private readonly FixtureSystem _fixture = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!; // HardLight
 
     public override void Initialize()
     {
         base.Initialize();
 
+        Subs.CVar(_cfg, CCVars.ShowCyborgSubtypeSprites, OnShowCyborgSubtypeSpritesChanged); // HardLight
         SubscribeLocalEvent<BorgSwitchableSubtypeComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<BorgSwitchableSubtypeComponent, AfterAutoHandleStateEvent>(OnAutoHandleEvent);
+    }
+
+    private void OnShowCyborgSubtypeSpritesChanged(bool _) // HardLight
+    {
+        var query = EntityQueryEnumerator<BorgSwitchableSubtypeComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            SelectBorgSubtype((uid, comp));
+        }
     }
 
     private void OnAutoHandleEvent(Entity<BorgSwitchableSubtypeComponent> ent, ref AfterAutoHandleStateEvent args)
@@ -50,7 +56,9 @@ public sealed class BorgSwitchableSubtypeSystem : SharedBorgSwitchableSubtypeSys
         // HardLight: Check if player has disabled custom borg sprites
         if (!_cfg.GetCVar(CCVars.ShowCyborgSubtypeSprites))
         {
-            // Don't apply custom appearance for remote entities
+            if (TryComp<BorgSwitchableTypeComponent>(entity, out var typeComp))
+                _borgTypeSystem.RefreshEntityAppearance((entity.Owner, typeComp), ignoreSubtype: true);
+
             return;
         }
 
@@ -63,12 +71,12 @@ public sealed class BorgSwitchableSubtypeSystem : SharedBorgSwitchableSubtypeSys
             return;
 
         // remove all existing layers
-        for (int i = chassisSprite.AllLayers.Count() - 1; i >= 0; i--)
+        for (var i = chassisSprite.AllLayers.Count() - 1; i >= 0; i--) // HardLight: int<var
         {
             _sprite.RemoveLayer((entity, chassisSprite), i);
         }
 
-        for (int i = 0; i < borgSubtypePrototype.LayerData.Length; i++)
+        for (var i = 0; i < borgSubtypePrototype.LayerData.Length; i++) // HardLight: int<var
         {
             var layerData = borgSubtypePrototype.LayerData[i];
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
As it says.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More convenient.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Toggling the visibility of unique Cyborg subtype sprites now reflects in-game without needing to refresh the client.
