### PR TITLE
Make hardsuits fit the bags

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -173,6 +173,8 @@
   - type: HeldSpeedModifier
   - type: Item
     size: Huge
+    shape:
+    - 0,0,1,1
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
   - type: DamageOnInteractProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -24,6 +24,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
@@ -63,6 +67,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
@@ -95,6 +103,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
@@ -124,6 +136,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
@@ -160,6 +176,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
@@ -192,6 +212,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitGoliath
@@ -229,6 +253,10 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMaxim
   - type: ContainerContainer
@@ -282,6 +310,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -309,6 +341,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -340,6 +376,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -372,6 +412,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
@@ -406,6 +450,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
@@ -434,6 +482,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
@@ -470,7 +522,7 @@
   - type: Item
     size: Huge
     shape:
-    - 0,0,4,4 #5X5, can fit in a duffel bag but nothing smaller.
+    - 0,0,3,3
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -512,6 +564,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
@@ -544,6 +600,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
@@ -560,6 +620,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,3,3
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: PressureProtection
@@ -666,6 +728,8 @@
         Caustic: 0.5
   - type: Item
     size: Huge
+    shape:
+    - 0,0,3,3
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 0.9
@@ -703,6 +767,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
@@ -737,6 +805,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.65
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
@@ -772,6 +844,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
@@ -802,6 +878,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
@@ -819,6 +899,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,1,1
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: ExplosionResistance
@@ -851,6 +933,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/piratecaptain.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,3,3
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/piratecaptain.rsi
   - type: PressureProtection
@@ -887,6 +971,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
 
@@ -931,6 +1019,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTMedical
   - type: ContainerContainer
@@ -968,6 +1060,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTSecurity
   - type: Tag
@@ -1070,6 +1166,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
@@ -1109,6 +1209,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
@@ -1140,6 +1244,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: Construction
     graph: ClownHardsuit
@@ -1190,6 +1298,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSanta

--- a/Resources/Prototypes/Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -26,6 +26,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.55
     sprintModifier: 0.55
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: StasisProtection
   - type: StasisBlinkProvider

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -7,5 +7,9 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/Hardsuits/ERTSuits/ertcentcomm.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/OuterClothing/Hardsuits/ERTSuits/ertcentcomm.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTCentcomm

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,6 +9,8 @@
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,4,4
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
   - type: PressureProtection

--- a/Resources/Prototypes/_HL/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -128,6 +128,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitInterdyne
 
@@ -212,6 +216,10 @@
     sprite: _HL/Clothing/OuterClothing/Hardsuits/colonialnavalinfantryHS.rsi
   - type: Clothing
     sprite: _HL/Clothing/OuterClothing/Hardsuits/colonialnavalinfantryHS.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitColonialNavalInfantry
   - type: ExplosionResistance
@@ -246,6 +254,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ExplosionResistance
     damageCoefficient: 0.6
@@ -495,6 +507,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxmax
   - type: HarpyHideWings # Frontier, needed for Harpies

--- a/Resources/Prototypes/_HL/Entities/Objects/Nanotrasen/clothing.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Nanotrasen/clothing.yml
@@ -28,6 +28,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetNT

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
@@ -8,6 +8,8 @@
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/ussp_combat.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,4,4
   - type: Clothing
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/ussp_combat.rsi
   - type: PressureProtection

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,6 +9,10 @@
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
 
@@ -23,5 +27,9 @@
     sprite: Clothing/OuterClothing/Hardsuits/piratecaptain.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/piratecaptain.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -26,6 +26,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMercenary
@@ -68,6 +72,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPilot
@@ -158,6 +166,10 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_bronze.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_bronze.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdBronze
   - type: ExplosionResistance
@@ -211,6 +223,10 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_sheriff.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_sheriff.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdSheriff
   - type: ExplosionResistance
@@ -293,6 +309,10 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_combat.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_combat.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdCombat
   - type: ExplosionResistance
@@ -321,6 +341,10 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_command.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_command.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,5,5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNfsdCommand
   - type: ExplosionResistance
@@ -365,6 +389,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitScaf
@@ -398,6 +426,10 @@
   - type: ClothingSpeedModifier # So many layers of stain protection makes it very heavy
     walkModifier: 0.75
     sprintModifier: 0.75
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,3,3
   - type: HeldSpeedModifier
   - type: FootstepModifier
     footstepSoundCollection:
@@ -415,6 +447,10 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/pirate_elite.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Hardsuits/pirate_elite.rsi
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateElite
   - type: ExplosionResistance

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -8,8 +8,9 @@
   id: NFClothingOuterEVASuitBase
   components:
   - type: Item
+    size: Huge
     shape:
-    - 0,0,3,2
+    - 0,0,1,1
   - type: Clothing
     # For immersion
     equipSound: /Audio/Mecha/mechmove03.ogg

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -29,5 +29,9 @@
         Caustic: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.6
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBlueshield


### PR DESCRIPTION
## About the PR
Hardsuits can be stored now in the bags.

Make EVA softsuits 2x2
Make basic/professional hardsuits 4x4
Make combat hardsuits (35%-60% protection) 5x5
Make remaining hardsuits (60%+ protection) 6x6

## Why / Balance
The idea is floating around during past months to make more hardsuits storeable in the bags.
Since right now the only common storeable  type of hardsuit is syndicate bloodred/elite hardsuit, it leads players to utilize them the most.
By adding more diverse, legally accepted and weaker hardsuits as valid options, this PR attempts to address the power creep and proliferation of C3 contra.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Most hardsuits can be stored
