### PR TITLE
Removes Drone Lawset from possible ions

### DIFF
--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -592,5 +592,5 @@
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5
-    Drone: 0.5
+    # Drone: 0.5 # Hardlight
 #    Ninja: 0.25 # Frontier


### PR DESCRIPTION

## About the PR
Title.

## Why / Balance
The drone lawset is... incredibly bad. It forces cyborgs to completely ignore everyone (even other borgs depending on interpretation), keeping them only working on the station/ship they're on, and also forces full pacifism. It does not lead to good RP due to the fact it actively disallows you to RP with others. So I am removing the ability for you to get stuck with it from ion.

## Technical details
Removed DroneLawset from weightedrandom

## How to test
Not really testable as it's a removal from a random weighted list

## Media
no

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: R3v3l4t1on
- remove: You can no longer get stuck with the Drone lawset from ions. No more "whoops can't RP anymore" incidents.
