### PR TITLE
Bluespace Bag speed nerf, 25% (30% tacpack of holding)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -296,7 +296,7 @@
   parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackHolding
   name: bag of holding
-  description: A backpack that opens into a localized pocket of bluespace.
+  description: A backpack that opens into a localized pocket of bluespace. It is unwieldy due to condensed gravitational emissions.
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Backpacks/holding.rsi # Frontier
@@ -328,6 +328,9 @@
     maxItemSize: Huge
     grid:
     - 0,0,19,9 # Frontier: Was 0,0,19,9 - FRONTIER MADE IT 0,0,7,7 AND THAT'S DUMB - Loki
+  - type: ClothingSpeedModifier
+    sprintModifier: 0.75 # movespeed nerf in exchange for massive storage
+  - type: HeldSpeedModifier
   - type: ChameleonClothing
     slot: [back]
     default: ClothingBackpackHolding

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -224,7 +224,7 @@
   parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelHolding
   name: duffelbag of holding
-  description: A duffelbag that opens into a localized pocket of bluespace.
+  description: A duffelbag that opens into a localized pocket of bluespace. It is unwieldy due to condensed gravitational emissions.
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Duffels/holding.rsi # Frontier
@@ -249,7 +249,7 @@
     grid:
     - 0,0,19,9 # Frontier: Was 0,0,19,9 - FRONTIER MADE IT 0,0,7,7 AND THAT'S DUMB - Loki
   - type: ClothingSpeedModifier
-    sprintModifier: 1 # makes its stats identical to other variants of bag of holding
+    sprintModifier: 0.75 # movespeed nerf in exchange for massive storage
   - type: HeldSpeedModifier
   - type: Clothing # Frontier
     sprite: _NF/Clothing/Back/Duffels/holding.rsi # Frontier

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -163,7 +163,7 @@
   parent: ClothingBackpackSatchel
   id: ClothingBackpackSatchelHolding
   name: satchel of holding
-  description: A satchel that opens into a localized pocket of bluespace.
+  description: A satchel that opens into a localized pocket of bluespace. It is unwieldy due to condensed gravitational emissions.
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Satchels/holding.rsi # Frontier
@@ -187,6 +187,9 @@
     maxItemSize: Huge
     grid:
     - 0,0,19,9 # Frontier: Was 0,0,19,9 - FRONTIER MADE IT 0,0,7,7 AND THAT'S DUMB - Loki
+  - type: ClothingSpeedModifier
+    sprintModifier: 0.75 # movespeed nerf in exchange for massive storage
+  - type: HeldSpeedModifier
   - type: Clothing # Frontier
     sprite: _NF/Clothing/Back/Satchels/holding.rsi # Frontier
     clothingVisuals: # Frontier

--- a/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
@@ -63,7 +63,7 @@
   id: ClothingBackpackTacticalHolding
   name: tactical pack of holding
   parent: [ NFClothingBackpack, RecyclableItemClothDurable ]
-  description: An extra large tactical pack for all your extra tacticool needs.
+  description: An extra large tactical pack for all your extra tacticool needs. It is unwieldy due to condensed gravitational emissions.
   components:
   - type: Sprite
     sprite: _HL/Clothing/Back/tacticalpack.rsi
@@ -93,6 +93,9 @@
   - type: ChameleonClothing
     slot: [back]
     default: ClothingBackpackTacticalHolding
+  - type: ClothingSpeedModifier
+    sprintModifier: 0.7 # movespeed nerf in exchange for massive storage
+  - type: HeldSpeedModifier
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
@@ -630,7 +630,7 @@
   parent: ClothingBackpackHolding
   id: ClothingBackpackMessengerHolding
   name: messenger bag of holding
-  description: A messenger bag that opens into a localized pocket of bluespace.
+  description: A messenger bag that opens into a localized pocket of bluespace. It is unwieldy due to condensed gravitational emissions.
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Messenger/holding.rsi
@@ -639,6 +639,9 @@
     - state: icon
     - state: icon-unlit
       shader: unshaded
+  - type: ClothingSpeedModifier
+    sprintModifier: 0.75 # movespeed nerf in exchange for massive storage
+  - type: HeldSpeedModifier
   - type: Clothing
     sprite: _NF/Clothing/Back/Messenger/holding.rsi
     clothingVisuals:


### PR DESCRIPTION
## About the PR
Changes Bluespace Bags (Bags of Holding) to have a 25% movespeed penalty to balance their large storage space. The Tac pack of holding instead has a 30% movespeed penalty, due to its larger storage space.

This does not impact normal bags, nor upgraded bags.

## Why / Balance
This is to encourage other bag options rather than the ultralarge Bags of Holding for everything. It gives more reason to use the middleground bags: `tactical pack`, `explorer pack`, and `rucksack`.

## Technical details
Adds the ClothingSpeedModifier and HeldSpeedModifier to all 5 bags of holding. Description has been slightly altered to inform of the movement speed change.

## How to test
Pull changes, spawn in each of the 5 bag types (`bag of holding`, `duffelbag of holding`, `satchel of holding`, `messengerbag of Holding`, `Tactical Pack of Holding`), observe the changes.

Load a saved ship, observe that bags loaded in this manner also have a changed movespeed penalty and description

## Media
<img width="827" height="508" alt="image" src="https://github.com/user-attachments/assets/b4ac9ac8-c299-4c25-9530-b8b2e98d1686" />
<img width="827" height="508" alt="image" src="https://github.com/user-attachments/assets/44ea1f38-e076-44c3-91be-7458b1c2712c" />
## Breaking changes
None known

**Changelog**
:cl:
- tweak: Bags of Holding now have a 25% move speed penalty, to encourage use of other bags such as: tactical pack, rucksack, explorer pack