### PR TITLE
Tweak bluespace tacpack to match 25% of other bags of holding

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/Back/upgraded_backpacks.yml
@@ -94,7 +94,7 @@
     slot: [back]
     default: ClothingBackpackTacticalHolding
   - type: ClothingSpeedModifier
-    sprintModifier: 0.7 # movespeed nerf in exchange for massive storage
+    sprintModifier: 0.75 # movespeed nerf in exchange for massive storage
   - type: HeldSpeedModifier
   - type: UserInterface
     interfaces:


### PR DESCRIPTION

## About the PR
quick fix since https://github.com/HardLightSector/HardLight/pull/1552 was merged, changes movespeed of tactical pack of holding to 25% to match other bags of holding.

See https://github.com/HardLightSector/HardLight/pull/1552 for more details