### PR TITLE
Remove fultons from stationside personnel (but not freelancers/salvagers)

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -383,7 +383,7 @@
   - MercenaryBelt
   - ContractorBoxSurvival
   - ContractorWallet
-  - ContractorImplanter
+  - FreelancerImplanter # HL: salvs + lancers get fultons
   - ContractorBackpackItems
   - ContractorHandItems
   - NFSpeciesSpecific

--- a/Resources/Prototypes/_HL/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,21 @@
+- type: entity
+  parent: BaseSubdermalImplant
+  id: MedicalTrackingImplantFulton
+  name: medical tracking implant
+  suffix: Fulton
+  description: This implant has a tracking device monitor for the Medical radio channel, as well as a bluespace fulton deployment device..
+#  categories: [ HideSpawnMenu ]
+  components:
+    - type: SubdermalImplant
+    - type: MedicalTeleportImplant
+      teleportDelay: 30
+      teleportDuration: 5
+      teleportSound:
+        path: /Audio/Effects/teleport_departure.ogg
+    - type: TriggerOnMobstateChange
+      mobState:
+      - Critical
+      - Dead
+      preventVore: true
+    - type: Rattle
+      radioChannel: "Medical"

--- a/Resources/Prototypes/_HL/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_HL/Loadouts/loadout_groups.yml
@@ -818,3 +818,18 @@
   - ServiceForcedClothingOuterEVASuit
   fallbacks:
   - ServiceForcedClothingOuterEVASuit
+
+- type: loadoutGroup
+  id: FreelancerImplanter
+  name: loadout-group-contractor-implanter
+  minLimit: 0
+  maxLimit: 2
+  loadouts:
+  - FreelancerMedicalTrackingImplanter
+  - ContractorLightImplanter
+  - ContractorBikeHornImplanter
+  - ContractorSadTromboneImplanter
+  - ContractorMimePowersImplanter
+  - ContractorBibleUserImplanter
+  fallbacks:
+  - FreelancerMedicalTrackingImplanter

--- a/Resources/Prototypes/_HL/Loadouts/loadouts.yml
+++ b/Resources/Prototypes/_HL/Loadouts/loadouts.yml
@@ -198,3 +198,10 @@
   storage:
     back:
     - WeaponShotgunVortex
+
+- type: loadout
+  id: FreelancerMedicalTrackingImplanter
+  name: medical tracking implanter
+  storage:
+    back:
+    - MedicalTrackingImplanterFulton

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -9,13 +9,13 @@
   components:
     - type: SubdermalImplant
     # Plays med radio alerts on critical/dead and now also schedules evac teleport on death
-    - type: MedicalTeleportImplant
-      # HL start: Add separate delay and duration, increase delay
-      teleportDelay: 30
-      teleportDuration: 5
-      # HL end
-      teleportSound:
-        path: /Audio/Effects/teleport_departure.ogg
+    # - type: MedicalTeleportImplant # Hardlight: Remove this for station personnel.
+    #   # HL start: Add separate delay and duration, increase delay
+    #   teleportDelay: 30
+    #   teleportDuration: 5
+    #   # HL end
+    #   teleportSound:
+    #     path: /Audio/Effects/teleport_departure.ogg
     # - type: SuitSensor # Hardlight: Remove this so manifest works fine.
     #   randomMode: false
     #   controlsLocked: true

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -73,7 +73,7 @@
   - MercenaryPDA
   - ContractorWallet
   - ContractorCartridge
-  - ContractorImplanter
+  - FreelancerImplanter # HL: only freelancers get trackers
   - ContractorBackpackItems
   - ContractorHandItems
   - NFSpeciesSpecific


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Station-side personnel no longer have fultons in their medical implants - freelancers, however, keep them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As it stands, Paramedics are entirely useless because everyone just gets fultonned. This changes that, while still allowing a lifeline/safety net for lancers who die in the far reaches of bumfuck nowhere.

Salvagers also get to keep their implant, because they're expected to run expeds and may need a fultonning.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- remove: Station-side personnel no longer get fultons.
