### PR TITLE
Un-nerfs storage module.

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/Back/backpacks.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: ClothingBackpackHolding
+  id: ClothingBackPackHoldingBorg
+  name: cyborg internal storage
+  description: Internalized storage that opens into a pocket of bluespace, adapted for cyborg use.
+  components:
+  - type: ClothingSpeedModifier
+    sprintModifier: 1

--- a/Resources/Prototypes/_HL/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_HL/Entities/Clothing/Back/backpacks.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: ClothingBackpackHolding
-  id: ClothingBackPackHoldingBorg
+  id: ClothingBackpackHoldingBorg
   name: cyborg internal storage
   description: Internalized storage that opens into a pocket of bluespace, adapted for cyborg use.
   components:

--- a/Resources/Prototypes/_HL/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -12,6 +12,6 @@
   - type: ItemBorgModule
     moduleId: Storage
     items:
-    - ClothingBackpackHolding
+    - ClothingBackpackHoldingBorg
   - type: BorgModuleIcon
     icon: { sprite: _HL/Interface/Actions/actions_borg.rsi, state: storage-module }


### PR DESCRIPTION

## About the PR
Removes the slowdown from the storage module added by accident.

## Why / Balance
When the bluespace bag changes were announced, it was said that cyborgs would be unaffected (mainly because, unlike humanoids, we cannot enhance our speed at all).
<img width="911" height="122" alt="image" src="https://github.com/user-attachments/assets/b67304d5-858b-44cb-a537-b6105c6a3a08" />
Then, https://github.com/HardLightSector/HardLight/pull/1552 got merged. But this did not account for cyborgs. So I'm fixing that by giving borgs a legally distinct bag of holding.


## Technical details
Made a new prototype, ClothingBackpackHoldingBorg, that parents off ClothingBackpackHolding. Gave it some unique flavor text and a single component to override the movement speed debuff from the bag. Changed BorgModuleStorage to use this backpack.

## How to test
Spawn in a borg
Spawn in BorgModuleStorage
Insert storage module into borg
take control of borg
open the module
inspect the slowdown

## Media

## Breaking changes
There's a very good chance this will break all existing storage modules. An announcement about this should be made before merging the PR to give players some time to empty out their modules.

**Changelog**

:cl: R3v3l4t1on
- tweak: Cyborgs are no longer slowed down if they have the storage module open.
