### PR TITLE
Gives the RD's headset binary again.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -323,13 +323,13 @@
   # HardLight start: Replaced starting encryption keys with intrinsic radio channels.
   - type: ActiveRadio
     intrinsicChannels:
-    - Trinary # HL: Move RD's headset to Trinary
+    - Binary
     - Command
     - Science
     - Common
   - type: EncryptionKeyHolder
     intrinsicChannels:
-    - Trinary # HL: Move RD's headset to Trinary
+    - Binary
     - Command
     - Science
     - Common


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The Research Director's regular and over-ear headset both have innate binary keys again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
One of the RD's main responsibilities is managing the station AI and cyborgs working as station crew. It only makes sense for them to have access to the channel dedicated to the station AI and silicons.

A nice little side-effect of the change is that it prevents synthetic RD's from sending all of their trinary messages twice, which is somewhat annoying.

## Technical details
<!-- Summary of code changes for easier review. -->
A few lines of yaml code changes.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn in an RD headset. Examine it. Chat to the station AI and stuff!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Research Director headsets come with binary keys again!
