### PR TITLE
Removes invalid configurators from TheDark.yml.

### DIFF
--- a/Resources/Maps/_HL/TheDark.yml
+++ b/Resources/Maps/_HL/TheDark.yml
@@ -4768,8 +4768,6 @@ entities:
       pos: 1.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 3
 - proto: GasVentScrubber
@@ -4780,8 +4778,6 @@ entities:
       pos: 0.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 3
 - proto: GeneratorBasic15kW


### PR DESCRIPTION

## About the PR
Title

## Why / Balance
Integration tests are failing on it.

## Technical details
Looked up and deleted all invalid references in TheDark.yml

## How to test
Run tests and confirm it's no longer failing

## Media

## Breaking changes
N/A

**Changelog**
:cl: R3v3l4t1on
- fix: Fixed a test
