### PR TITLE
Add missing ammo boxes

### DIFF
--- a/Resources/Prototypes/_HL/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_HL/Recipes/Lathes/ammo.yml
@@ -112,6 +112,30 @@
     Plastic: 1500
 
 - type: latheRecipe
+  id: AmmoBoxBigPractice
+  abstract: true
+  completetime: 5
+  materials:
+    Steel: 450
+
+- type: latheRecipe
+  id: AmmoBoxBigIncendiary
+  abstract: true
+  completetime: 5
+  materials:
+    Steel: 900
+    Plastic: 1800
+    Plasma: 2700
+
+- type: latheRecipe
+  id: AmmoBoxBigUranium
+  abstract: true
+  completetime: 5
+  materials:
+    Steel: 1500
+    Uranium: 3000
+
+- type: latheRecipe
   id: AmmoBox46x30mmBig
   parent: AmmoBoxBig
   result: AmmoBox46x30mmBig
@@ -150,6 +174,31 @@
   id: AmmoBox9x19mmBigFMJ
   parent: AmmoBoxBig
   result: AmmoBox9x19mmBigFMJ
+
+- type: latheRecipe
+  id: AmmoBox45_ACPBigFMJ
+  parent: AmmoBoxBig
+  result: AmmoBox45_ACPBigFMJ
+
+- type: latheRecipe
+  id: AmmoBox45_ACPBigPractice
+  parent: AmmoBoxBigPractice
+  result: AmmoBox45_ACPBigPractice
+
+- type: latheRecipe
+  id: AmmoBox45_ACPBigRubber
+  parent: AmmoBoxBigRubber
+  result: AmmoBox45_ACPBigRubber
+
+- type: latheRecipe
+  id: AmmoBox45_ACPBigIncendiary
+  parent: AmmoBoxBigIncendiary
+  result: AmmoBox45_ACPBigIncendiary
+
+- type: latheRecipe
+  id: AmmoBox45_ACPBigUranium
+  parent: AmmoBoxBigUranium
+  result: AmmoBox45_ACPBigUranium
 
 - type: latheRecipe
   id: AmmoBox762x51mmRubberBig

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
@@ -45,6 +45,70 @@
     zeroVisible: false
   - type: Appearance
 
+- type: entity # Mono Big Pistol Mags
+  parent: AmmoBox45_ACPBigFMJ
+  id: AmmoBox45_ACPBigPractice
+  name: ammunition box (.45 ACP practice)
+  suffix: Big
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45_ACPPractice
+  - type: Sprite
+    layers:
+    - state: base-b
+      map: ["enum.GunVisualLayers.Base"]
+    - state: magb-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: practice
+
+- type: entity # Mono Big Pistol Mags
+  parent: AmmoBox45_ACPBigFMJ
+  id: AmmoBox45_ACPBigRubber
+  name: ammunition box (.45 ACP rubber)
+  suffix: Big
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45_ACPRubber
+  - type: Sprite
+    layers:
+    - state: base-b
+      map: ["enum.GunVisualLayers.Base"]
+    - state: magb-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: rubber
+
+- type: entity # Mono Big Pistol Mags
+  parent: AmmoBox45_ACPBigFMJ
+  id: AmmoBox45_ACPBigIncendiary
+  name: ammunition box (.45 ACP incendiary)
+  suffix: Big
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45_ACPIncendiary
+  - type: Sprite
+    layers:
+    - state: base-b
+      map: ["enum.GunVisualLayers.Base"]
+    - state: magb-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: incendiary
+
+- type: entity # Mono Big Pistol Mags
+  parent: AmmoBox45_ACPBigFMJ
+  id: AmmoBox45_ACPBigUranium
+  name: ammunition box (.45 ACP uranium)
+  suffix: Big
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45_ACPUranium
+  - type: Sprite
+    layers:
+    - state: base-b
+      map: ["enum.GunVisualLayers.Base"]
+    - state: magb-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: uranium
+
 - type: entity
   parent: BaseAmmoBox45_ACP
   id: AmmoBox45_ACPFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -381,6 +381,12 @@
   - AmmoBox762x51mmBigFMJ
   - AmmoBox762x54mmRBigFMJ
   - AmmoBox9x19mmBigFMJ
+  - AmmoBox45_ACPBigFMJ
+  - AmmoBox45_ACPBigPractice
+  - AmmoBox45_ACPBigRubber
+  - AmmoBox45_ACPBigIncendiary
+  - AmmoBox45_ACPBigUranium
+  - AmmoBox57x28mmBig
   - AmmoBox762x51mmRubberBig
   - AmmoBox762x39mmRubberBig
   - AmmoBox762x54mmRRubberBig
@@ -539,6 +545,10 @@
   - AmmoBox762x51mmBigFMJ
   - AmmoBox762x54mmRBigFMJ
   - AmmoBox9x19mmBigFMJ
+  - AmmoBox45_ACPBigFMJ
+  - AmmoBox45_ACPBigPractice
+  - AmmoBox45_ACPBigRubber
+  - AmmoBox57x28mmBig
   - AmmoBox762x51mmRubberBig
   - AmmoBox762x39mmRubberBig
   - AmmoBox762x54mmRRubberBig
@@ -557,6 +567,7 @@
   - Magazine45_ACPPistolIncendiary
   - Magazine45_ACPSubMachineGunIncendiary
   - AmmoBox45_ACPIncendiary
+  - AmmoBox45_ACPBigIncendiary
   - Magazine9x19mmPistolIncendiary
   - Magazine9x19mmSubMachineGunIncendiary
   - SpeedLoader9x19mmIncendiary
@@ -587,6 +598,7 @@
   - Magazine45_ACPPistolUranium
   - Magazine45_ACPSubMachineGunUranium
   - AmmoBox45_ACPUranium
+  - AmmoBox45_ACPBigUranium
   - Magazine9x19mmPistolUranium
   - Magazine9x19mmSubMachineGunUranium
   - SpeedLoader9x19mmUranium


### PR DESCRIPTION

## About the PR
Add missing ammo boxes: .45 ACP and 57x28

## Why / Balance
Assets are in the game, seems they just were left out by a mistake

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Add missing ammo boxes