### PR TITLE
Make Cryosleep Units Great Again

### DIFF
--- a/Content.Server/_NF/CryoSleep/CryoSleepSystem.Returning.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepSystem.Returning.cs
@@ -22,7 +22,6 @@ public sealed partial class CryoSleepSystem
     private void InitReturning()
     {
         SubscribeNetworkEvent<WakeupRequestMessage>(OnWakeupMessage);
-        SubscribeLocalEvent<PlayerJoinedLobbyEvent>(e => ResetCryosleepState(e.PlayerSession.UserId));
         SubscribeLocalEvent<PlayerBeforeSpawnEvent>(e => ResetCryosleepState(e.Player.UserId));
     }
 
@@ -55,6 +54,12 @@ public sealed partial class CryoSleepSystem
 
         var cryopod = storedBody!.Value.Cryopod;
         var body = storedBody.Value.Body;
+        if (!Exists(body) || Deleted(body)) // HardLight
+        {
+            ResetCryosleepState(id.Value);
+            return ReturnToBodyStatus.BodyMissing;
+        }
+
         if (!Exists(cryopod) || Deleted(cryopod) || !TryComp<CryoSleepComponent>(cryopod, out var cryoComp))
         {
             var fallbackQuery = EntityQueryEnumerator<CryoSleepFallbackComponent, CryoSleepComponent>();
@@ -79,6 +84,7 @@ public sealed partial class CryoSleepSystem
                 return ReturnToBodyStatus.Occupied;
         }
 
+        UnregisterCryostorageBody(body, cryopod); // HardLight
         _storedBodies.Remove(id.Value);
         _mind.ControlMob(id.Value, body);
         // Force the mob to sleep

--- a/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
@@ -72,6 +72,7 @@ public sealed partial class CryoSleepSystem : EntitySystem
         SubscribeLocalEvent<CryoSleepComponent, DestructionEventArgs>((e, c, _) => EjectBody(e, c));
         SubscribeLocalEvent<CryoSleepComponent, CryoStoreDoAfterEvent>(OnAutoCryoSleep);
         SubscribeLocalEvent<CryoSleepComponent, DragDropTargetEvent>(OnEntityDragDropped);
+        SubscribeLocalEvent<CryostorageContainedComponent, EntityTerminatingEvent>(OnCryostorageContainedTerminating); // HardLight
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
 
         InitReturning();
@@ -218,6 +219,12 @@ public sealed partial class CryoSleepSystem : EntitySystem
         args.Handled |= InsertBody(args.Dragged, ent, false);
     }
 
+    private void OnCryostorageContainedTerminating(Entity<CryostorageContainedComponent> ent, ref EntityTerminatingEvent args) // HardLight
+    {
+        if (ent.Comp.UserId is { } userId)
+            ResetCryosleepState(userId);
+    }
+
     public bool InsertBody(EntityUid? toInsert, Entity<CryoSleepComponent> cryopod, bool force)
     {
         if (toInsert == null)
@@ -286,7 +293,8 @@ public sealed partial class CryoSleepSystem : EntitySystem
         if (!TryComp<CryoSleepComponent>(cryopod, out var cryo))
             return;
 
-        // HardLight start: Body may have unrelated active do-afters.
+        // HardLight start
+        // Body may have unrelated active do-afters.
         // Clear them before moving to paused cryospace,
         // otherwise update-driven cleanup can leave client-side bars frozen indefinitely.
         _doAfter.CancelAndClearAll(bodyId);
@@ -321,7 +329,8 @@ public sealed partial class CryoSleepSystem : EntitySystem
         _container.Remove(bodyId, cryo.BodyContainer, reparent: false, force: true);
         UpdateOccupancyAppearance(cryopod, false); // HardLight
         _transform.SetCoordinates(bodyId, new EntityCoordinates(storage, Vector2.Zero));
-
+        if (!deleteEntity)
+            RegisterCryostorageBody(bodyId, cryopod, id); // HardLight
         RaiseLocalEvent(bodyId, new CryosleepEnterEvent(cryopod, mind?.UserId), true);
 
         if (deleteEntity)
@@ -369,15 +378,45 @@ public sealed partial class CryoSleepSystem : EntitySystem
         return component.BodyContainer.ContainedEntity != null;
     }
 
-    // HardLight start: Method to update the visual state of the cryopod based on whether it's occupied or not.
-    // It is called whenever a body is inserted or ejected from the pod.
-    private void UpdateOccupancyAppearance(EntityUid uid, bool occupied)
+    private void RegisterCryostorageBody(EntityUid body, EntityUid cryopod, NetUserId? userId) // HardLight
+    {
+        if (!TryComp<CryostorageComponent>(cryopod, out var cryostorage))
+            return;
+
+        var contained = EnsureComp<CryostorageContainedComponent>(body);
+        contained.Cryostorage = cryopod;
+        contained.UserId = userId;
+        Dirty(body, contained);
+
+        if (!cryostorage.StoredPlayers.Contains(body))
+        {
+            cryostorage.StoredPlayers.Add(body);
+            Dirty(cryopod, cryostorage);
+        }
+    }
+
+    private void UnregisterCryostorageBody(EntityUid body, EntityUid cryopod) // HardLight
+    {
+        if (TryComp<CryostorageContainedComponent>(body, out var contained))
+        {
+            contained.Cryostorage = null;
+            contained.UserId = null;
+            Dirty(body, contained);
+        }
+
+        if (!TryComp<CryostorageComponent>(cryopod, out var cryostorage))
+            return;
+
+        if (cryostorage.StoredPlayers.Remove(body))
+            Dirty(cryopod, cryostorage);
+    }
+
+    private void UpdateOccupancyAppearance(EntityUid uid, bool occupied) // HardLight
     {
         _appearance.SetData(uid, CryostorageVisuals.Full, occupied);
     }
 
-    // HardLight start: Method to cancel the auto-cryo-sleep do-after event associated with a cryopod.
-    private void CancelCryoStoreDoAfter(CryoSleepComponent component)
+    private void CancelCryoStoreDoAfter(CryoSleepComponent component) // HardLight
     {
         var doAfterId = component.CryosleepDoAfter;
         component.CryosleepDoAfter = null;
@@ -387,7 +426,6 @@ public sealed partial class CryoSleepSystem : EntitySystem
 
         _doAfter.Cancel(doAfterId);
     }
-    // HardLight end
 
     private void OnRoundRestart(RoundRestartCleanupEvent args)
     {

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -109,12 +109,18 @@ namespace Content.Shared.Ghost
             if (!Resolve(uid, ref component))
                 return;
 
+            // HardLight start
+            if (component.CanReturnFromCryo == value)
+                return;
+
             component.CanReturnFromCryo = value;
+            Dirty(uid, component);
+            // HardLight end
         }
 
         public void SetCanReturnFromCryo(GhostComponent component, bool value)
         {
-            component.CanReturnFromCryo = value;
+            SetCanReturnFromCryo(component.Owner, value, component); // HardLight
         }
         // Frontier: uncryo status (mirroring CanReturnToBody)
     }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -103,7 +103,7 @@ namespace Content.Shared.Roles
         /// Nyano/DV: For e.g. prisoners, they'll never use their latejoin spawner.
         /// </summary>
         [DataField("alwaysUseSpawner")]
-        public bool AlwaysUseSpawner { get; } = true;
+        public bool AlwaysUseSpawner { get; } = false; // HardLight: true<false; why was this true?
 
         /// <summary>
         ///     The "weight" or importance of this job. If this number is large, the job system will assign this job

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -30,7 +30,7 @@ public sealed class NFCCVars
     /// Whether or not returning from cryosleep is enabled.
     /// </summary>
     public static readonly CVarDef<bool> CryoReturnEnabled =
-        CVarDef.Create("nf14.uncryo.enabled", false, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.uncryo.enabled", true, CVar.SERVER | CVar.REPLICATED); // Livyathan: false<true; bodies in cryospace persist for 10 minutes. Might as well let them come back since the body is there, anyway.
 
     /// <summary>
     /// The time in seconds after which a cryosleeping body is considered expired and can be deleted from the storage map.

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -62816,12 +62816,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,-12.5
       parent: 2
+- proto: CryogenicSleepUnitSpawner
+  entities:
   - uid: 9974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-11.5
       parent: 2
+- proto: CryogenicSleepUnitSpawnerLateJoin
+  entities:
   - uid: 9975
     components:
     - type: Transform

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -4,8 +4,7 @@
   name: cryogenic sleep unit
   description: A super-cooled container that keeps crewmates safe during space travel.
   components:
-# HardLight start
-#  - type: Anchorable
+#  - type: Anchorable # HardLight
 #    flags:
 #    - Anchorable
   - type: Transform
@@ -16,22 +15,22 @@
     layers:
     - state: sleeper_0
       map: ["base"]
-#  - type: UserInterface
-#    interfaces:
-#      enum.CryostorageUIKey.Key:
-#        type: CryostorageBoundUserInterface
-#  - type: ActivatableUI
-#    key: enum.CryostorageUIKey.Key
-#  - type: AccessReader
-#    breakOnAccessBreaker: false
-#    access: [["Cryogenics"]]
-#  - type: InteractionOutline
+  - type: UserInterface
+    interfaces:
+      enum.CryostorageUIKey.Key:
+        type: CryostorageBoundUserInterface
+  - type: ActivatableUI
+    key: enum.CryostorageUIKey.Key
+  - type: AccessReader
+    breakOnAccessBreaker: false
+    access: [["Cryogenics"]]
+  - type: InteractionOutline
   - type: Cryostorage
-#  - type: Physics
-#    canCollide: false
-#  - type: DragInsertContainer
-#    containerId: storage
-#    entryDelay: 2
+  - type: Physics
+    canCollide: false
+  - type: DragInsertContainer
+    containerId: storage
+    entryDelay: 2
   - type: ExitContainerOnMove
     containerId: storage
   - type: PointLight
@@ -42,7 +41,6 @@
   - type: ContainerContainer
     containers:
       storage: !type:ContainerSlot
-# HardLight end
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -32,16 +32,16 @@
 #  - type: DragInsertContainer
 #    containerId: storage
 #    entryDelay: 2
-#  - type: ExitContainerOnMove
-#    containerId: storage
+  - type: ExitContainerOnMove
+    containerId: storage
   - type: PointLight
     color: Lime
     radius: 1.5
     energy: 0.5
     castShadows: false
-#  - type: ContainerContainer
-#    containers:
-#      storage: !type:ContainerSlot
+  - type: ContainerContainer
+    containers:
+      storage: !type:ContainerSlot
 # HardLight end
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/_HL/Roles/Jobs/Misc/anomaly.yml
+++ b/Resources/Prototypes/_HL/Roles/Jobs/Misc/anomaly.yml
@@ -4,6 +4,7 @@
   description: job-description-anomaly
   playTimeTracker: RoleAnomaly
   overrideConsoleVisibility: true
+  alwaysUseSpawner: true
   canBeAntag: false
   icon: "JobIconNoId"
   joinNotifyCrew: false

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/valet.yml
@@ -9,7 +9,7 @@
       time: 10800
   weight: -40 # HardLight
   startingGear: ValetGear
-  alwaysUseSpawner: true
+  alwaysUseSpawner: false # HardLight: true<false
   icon: "JobIconValet" # Frontier: JobIconServiceWorker<JobIconValet
   supervisors: job-supervisors-sr
   canBeAntag: false

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -62,7 +62,7 @@
     time: 36000 # 10 hrs
   weight: 10
   startingGear: SrGear
-  alwaysUseSpawner: true
+  alwaysUseSpawner: false
   icon: "JobIconHarborMaster"
   setPreference: true
   supervisors: job-supervisors-centcom

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
@@ -4,7 +4,7 @@
   description: job-description-stc
   playTimeTracker: JobStc
   startingGear: StcGear
-  alwaysUseSpawner: true
+  alwaysUseSpawner: false # HardLight: true<false
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hrs

--- a/Resources/Prototypes/_NF/Roles/Jobs/Service/mail_carrier.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Service/mail_carrier.yml
@@ -3,7 +3,7 @@
   name: job-name-mail-carrier
   description: job-description-mail-carrier
   startingGear: MailCarrierGear
-  alwaysUseSpawner: true
+  alwaysUseSpawner: false # HardLight: true<false
   playTimeTracker: JobMailCarrier
   requirements:
     - !type:OverallPlaytimeRequirement


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Does a handful of things:

Fixes cryosleep spawn priority not doing anything. Late-join cryosleep spawns once again work, or finally work if they never did.

Restores cut functionalities to cryosleep units, including: body registering for item recovery, the un-cryo functionality that allows players to exit cryo should their bodies not be deleted (it's a 10 minute window from entering cryo to being deleted), and— actually, that's it.

Also fixes some Frontier jobs not being allowed to use late-join spawns. Prisoners still spawn in jail.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
[ Everyone liked that ]

## Technical details
<!-- Summary of code changes for easier review. -->
Changes the NFCCvar for un-cryo false<true.

Plus some other C# changes that are mentioned above.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Shouldn't even cause the smallest amount of lag. Currently, cryo still outputs bodies to cryospace for exactly 10 minutes. After 10 minutes, those bodies are deleted. If the bodies are THERE anyway, players might as well be able to reconnect to them and exit cryo.

It shouldn't change anything besides improving user experience.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Un-cryo has been re-enabled for use so long as the target body is still present in cryospace.
- tweak: Cryosleep units once again have a UI.
- fix: Cryosleep as a spawn priority now functions again.
- fix: Cryosleep units now correctly register actively present bodies and allow items to be retrieved from them.
