### PR TITLE
Port of amputee trait from DV

### DIFF
--- a/Content.Server/_DV/Traits/Assorted/AmputeeComponent.cs
+++ b/Content.Server/_DV/Traits/Assorted/AmputeeComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Body.Part;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Traits.Assorted;
+
+[RegisterComponent]
+public sealed partial class AmputeeComponent : Component
+{
+    [DataField]
+    public BodyPartType RemoveBodyPart { get; private set; } = BodyPartType.Arm;
+
+    [DataField]
+    public BodyPartSymmetry PartSymmetry { get; private set; } = BodyPartSymmetry.Left;
+
+    /// <summary>
+    /// Body part prototype to use as a replacement limb, if applicable.
+    /// </summary>
+    [DataField]
+    public EntProtoId? ProtoId { get; private set; }
+
+    [DataField]
+    public string? SlotId { get; private set; } = "left arm";
+}

--- a/Content.Server/_DV/Traits/Assorted/AmputeeSystem.cs
+++ b/Content.Server/_DV/Traits/Assorted/AmputeeSystem.cs
@@ -1,0 +1,56 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Robust.Server.GameObjects;
+
+namespace Content.Server._DV.Traits.Assorted;
+
+public sealed class AmputeeSystem : EntitySystem
+{
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AmputeeComponent, MapInitEvent>(OnMapInit);
+    }
+    // Logic here taken from Den at https://github.com/TheDenSS14/TheDen/blob/d6f85a10fccf0f282981438e55b808d7ece73ad9/Content.Server/Traits/TraitSystem.Functions.cs
+    private void OnMapInit(Entity<AmputeeComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp(ent, out BodyComponent? body) || !TryComp(ent, out TransformComponent? xform))
+            return;
+
+        var root = _body.GetRootPartOrNull(ent, body);
+        if (root is null)
+            return;
+
+        var parts = _body.GetBodyChildrenOfType(ent, ent.Comp.RemoveBodyPart, body);
+        foreach (var part in parts)
+        {
+            var partComp = part.Component;
+            if (partComp.Symmetry != ent.Comp.PartSymmetry)
+                continue;
+
+            foreach (var child in _body.GetBodyPartChildren(part.Id, part.Component))
+            {
+                QueueDel(child.Id);
+            }
+
+            _transform.AttachToGridOrMap(part.Id);
+            QueueDel(part.Id);
+
+            // apparently chopping off limbs makes people bleed a lot. Who would have guessed?
+            _bloodstream.TryModifyBleedAmount(ent.Owner, -10f);
+
+            // goes unused for the purposes of the arm amputee traits, but might as well keep it in
+            if (ent.Comp.ProtoId is null || ent.Comp.SlotId == null)
+                continue;
+
+            var newLimb = SpawnAtPosition(ent.Comp.ProtoId, xform.Coordinates);
+            if (TryComp<BodyPartComponent>(newLimb, out var limbComp) && limbComp.Symmetry == ent.Comp.PartSymmetry)
+                _body.AttachPart(root.Value.Entity, ent.Comp.SlotId, newLimb, root.Value.BodyPart, limbComp);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -12,3 +12,13 @@ trait-uncloneable-desc = You cannot be cloned.
 
 trait-unborgable-name = Machine Incompatible
 trait-unborgable-desc = Your brain cannot be put into a man-machine interface.
+
+trait-amputee-left-arm-name = Amputee (Arm, Left)
+trait-amputee-left-arm-desc =
+    Your left arm is missing!
+    (Note: Amputee traits do not appear in the character editor preview!)
+
+trait-amputee-right-arm-name = Amputee (Arm, Right)
+trait-amputee-right-arm-desc =
+    Your right arm is missing!
+    (Note: Amputee traits do not appear in the character editor preview!)

--- a/Resources/Prototypes/_HL/Traits/Physical.yml
+++ b/Resources/Prototypes/_HL/Traits/Physical.yml
@@ -349,3 +349,29 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/Animals/fox_squeak.ogg
+
+- type: trait
+  id: ArmAmputeeL
+  name: trait-amputee-left-arm-name
+  description: trait-amputee-left-arm-desc
+  category: Physical
+  cost: -6
+  mutuallyExclusiveTraits:
+  - ArmAmputeeR
+  components:
+  - type: Amputee
+    removeBodyPart: Arm
+    partSymmetry: Left
+
+- type: trait
+  id: ArmAmputeeR
+  name: trait-amputee-right-arm-name
+  description: trait-amputee-right-arm-desc
+  category: Physical
+  cost: -6
+  mutuallyExclusiveTraits:
+  - ArmAmputeeL
+  components:
+  - type: Amputee
+    removeBodyPart: Arm
+    partSymmetry: Right


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Port of Delta-v #4988
Adds an amputee trait for a (open to change) -6 cost
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Good for character building if you want to sustain a permanent injury. Plus i have an amputee character i want to play here :)
## Technical details
<!-- Summary of code changes for easier review. -->
Adds AmputeeComponent from DV
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Load devenv. Spend 50 minutes debugging 5 minute change. Cry. Repeat. Finally have it work as intended despite changing nothing. Cry more.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="619" height="103" alt="image" src="https://github.com/user-attachments/assets/cc2f20a7-bda5-4f5f-be96-23204fc286e0" />
<img width="100" height="91" alt="image" src="https://github.com/user-attachments/assets/41f4ddad-abda-4117-a188-94c598e5c488" />
<img width="260" height="60" alt="image" src="https://github.com/user-attachments/assets/f4cca313-cf78-4f9b-8855-5e154eade068" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added an amputee trait. one for both arms

