### PR TITLE
Small fix to borg guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Science/Cyborgs.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Cyborgs.xml
@@ -27,6 +27,7 @@
     <GuideEntityEmbed Entity="BorgChassisJanitor" Caption="Janitor"/>
     <GuideEntityEmbed Entity="BorgChassisService" Caption="Service"/>
     <GuideEntityEmbed Entity="BorgChassisMedical" Caption="Medical"/>
+    <GuideEntityEmbed Entity="BorgChassisSecurity" Caption="Security"/>
   </Box>
   <Box>
     [italic]Examples of various cyborg types[/italic]
@@ -42,8 +43,8 @@
   [color=#a4885c]Generic[/color] modules add versatility. They can be fitted into any chassis, granting useful tools such as crowbars, GPS, and the ability to interact with cables. [bold]The generic cyborg chassis can fit up to five additional modules.[/bold]
   <Box>
     <GuideEntityEmbed Entity="BorgModuleCable" Caption="Cable"/>
-    <GuideEntityEmbed Entity="BorgModuleGPS" Caption="GPS"/>
-    <GuideEntityEmbed Entity="BorgModuleFireExtinguisher" Caption="Fire Extinguisher"/>
+    <GuideEntityEmbed Entity="BorgModuleTool" Caption="Tools"/>
+    <GuideEntityEmbed Entity="BorgModuleJetpack" Caption="Frontier"/>
   </Box>
   <Box>
     [italic]Examples of generic modules[/italic]
@@ -56,7 +57,7 @@
     <GuideEntityEmbed Entity="BorgModuleMining" Caption="Mining"/>
     <GuideEntityEmbed Entity="BorgModuleCleaning" Caption="Cleaning"/>
     <GuideEntityEmbed Entity="BorgModuleService" Caption="Service"/>
-    <GuideEntityEmbed Entity="BorgModuleTreatment" Caption="Treatment"/>
+    <GuideEntityEmbed Entity="BorgModuleChemical" Caption="Chemical"/>
   </Box>
   <Box>
     [italic]Examples of specialized modules. Note the housing and circuit board colors.


### PR DESCRIPTION

## About the PR
Replaced some invalid references in the cyborg guidebook and added the security borg.

## Why / Balance
Because eventually we do want the integration tests to run succesfully.

## Technical details
Changed BorgModuleFireExtinguisher to BorgModuleJetpack, BorgModuleGPS to BorgModuleTool and BorgModuleTreatment to BorgModuleChemical. Also added a new embed for the security cyborg.

## How to test
Open game
Spawn borg
Click the guidebook page
Note no errors

## Media
nuh

## Breaking changes
None

**Changelog**
:cl: R3v3l4t1on
- fix: Fixed invalid entries in cyborg guidebook
