### PR TITLE
Gives all map posters deconstruction steps + makes them constructible.

### DIFF
--- a/Resources/Prototypes/_HL/Recipes/Construction/Graphs/signs/poster.yml
+++ b/Resources/Prototypes/_HL/Recipes/Construction/Graphs/signs/poster.yml
@@ -600,6 +600,63 @@
               amount: 1
               doAfter: 1
 
+    # Legit Poster Nodes
+        - to: PosterMapBagel
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapDelta
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapMarathon
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapMoose
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapPacked
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapPillar
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapSaltern
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapSplit
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapLighthouse
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapWaystation
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+        - to: PosterMapOrigin
+          steps:
+            - material: Paper
+              amount: 1
+              doAfter: 1
+
     # Contraband Poster Nodes
     - node: PosterContrabandFreeTonto
       entity: PosterContrabandFreeTonto
@@ -1890,9 +1947,130 @@
           steps:
             - tool: Prying
               doAfter: 1
-
     - node: PosterDuskEnclave
       entity: PosterDuskEnclave
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    #Map Poster Nodes
+    - node: PosterMapBagel
+      entity: PosterMapBagel
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapDelta
+      entity: PosterMapDelta
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapMarathon
+      entity: PosterMapMarathon
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapMoose
+      entity: PosterMapMoose
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapPacked
+      entity: PosterMapPacked
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapPillar
+      entity: PosterMapPillar
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapSaltern
+      entity: PosterMapSaltern
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapSplit
+      entity: PosterMapSplit
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapLighthouse
+      entity: PosterMapLighthouse
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapWaystation
+      entity: PosterMapWaystation
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPaper
+              amount: 1
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: PosterMapOrigin
+      entity: PosterMapOrigin
       edges:
         - to: start
           completed:

--- a/Resources/Prototypes/_HL/Recipes/Construction/posters.yml
+++ b/Resources/Prototypes/_HL/Recipes/Construction/posters.yml
@@ -1569,3 +1569,146 @@
   canBuildInImpassable: true
   conditions:
     - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapBagel
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapBagel
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapDelta
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapDelta
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapMarathon
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapMarathon
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapMoose
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapMoose
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapPacked
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapPacked
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapPillar
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapPillar
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapSaltern
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapSaltern
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapSplit
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapSplit
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapLighthouse
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapLighthouse
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapWaystation
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapWaystation
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  id: PosterMapOrigin
+  graph: Poster
+  startNode: start
+  targetNode: PosterMapOrigin
+  category: construction-category-Poster
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Someone gave all the maps a reference to a being able to get deconned. But they forgot to actually add steps for this. So I fixed that. Whilst I was at it, I gave them construction menu entries as well.

## Technical details
Adds (de)construction steps for all the posters of station maps and adds entries for them in the build menu

## How to test
Spawn in
Open build menu
Go to posters category
Look for a map poster
Make it (construction pending)
Decon it

## Media
no

## Breaking changes
none

**Changelog**
:cl: R3v3l4t1on
- add: Station map posters can be constructed from the build menu.
- fix: Station map posters can now actually be deconstructed.
