### PR TITLE
Fixes HeadsetKeys

### DIFF
--- a/Content.IntegrationTests/Tests/EncryptionKeys/RemoveEncryptionKeys.cs
+++ b/Content.IntegrationTests/Tests/EncryptionKeys/RemoveEncryptionKeys.cs
@@ -12,6 +12,7 @@ public sealed class RemoveEncryptionKeys : InteractionTest
     {
         await SpawnTarget("ClothingHeadsetGrey");
         var comp = Comp<EncryptionKeyHolderComponent>();
+        await InteractUsing("EncryptionKeyCommon");// Hardlight: Our headsets have intrinsic keys, as such we've got to add a common key first to perform the test.
 
         Assert.Multiple(() =>
         {


### PR DESCRIPTION
## About the PR
Fixes a test.

## Why / Balance
HardLight changed all headsets to have intrinsic comms channels. This however broke the HeadsetKeys as it relies on the headset having keys. Inserting a key before trying the test should fix this.

## Technical details
Added a single await to insert a key.

## How to test
Run the test

## Media

## Breaking changes
None.

**Changelog**
:cl: R3v3l4t1on
- fix: Knocks another test off the list of failing tests
