### PR TITLE
Re-enable THE ROD

### DIFF
--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -33,7 +33,7 @@
     - id: GameRuleMeteorSwarmMedium
     - id: GameRuleMeteorSwarmLarge
     - id: GameRuleUristSwarm
-    #- id: ImmovableRodSpawn
+    - id: ImmovableRodSpawn
 
 - type: weightedRandomEntity
   id: MeteorSpawnAsteroidWallTable
@@ -203,7 +203,7 @@
     startAnnouncement: station-event-immovable-rod-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 0
+    weight: 3.5
     reoccurrenceDelay: 200
     duration: 1
     earliestStart: 30


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Sometimes I like to see the world burn.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It gives ENG something to do.

It was originally removed because people hated getting their ships hit by rods. I'd like to think HardLight has stopped handholding people since then, and ships are now normally detached from the station thanks to the docks. Since rods spawn close to the station, I believe closer than the docks do, ships should only be threatened if they are docked to the station. In translation: don't dock to the station any longer than you need to or get violently penetrated.

And the rod is funny.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Stations.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: I resurrected the rod.

