### PR TITLE
Issue #1585 Jet injectors in medical bags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -209,6 +209,10 @@
     maxFillLevels: 3
     fillBaseName: jetinjector_filled
     solutionName: hypospray
+  - type: Tag
+    tags:
+    - JetInjector
+
 
 - type: entity
   parent: JetInjector

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/medical_bag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/medical_bag.yml
@@ -32,6 +32,7 @@
         - Bloodpack
         - Gauze
         - Bottle
+        - JetInjector
   - type: Dumpable
   - type: MagnetPickup
     magnetEnabled: false

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1584,7 +1584,9 @@
 
 - type: Tag
   id: CartridgeShell
-  
+
 - type: Tag
   id: BoneArmor
 
+- type: Tag
+  id: JetInjector


### PR DESCRIPTION

## About the PR
Added a tag for jet injectors and whitelisted the tag for medical bags.
Reported in #1585 
## Why / Balance
Hyposprays fit in there, jet injectors should too

## How to test
Spawn Medical bag, spawn all 3 types of injectors, add them to the bag

## Media
<img width="369" height="150" alt="image" src="https://github.com/user-attachments/assets/8c622b12-7b29-4dd9-85da-2298b7ebcb3b" />

**Changelog**

:cl:
- fix: jet injectors now fit in medical bags

