### PR TITLE
Fixes the kitsune squeak to use the correct sound (/Audio/_DV/Voice/K…

### DIFF
--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -315,7 +315,7 @@
     Gekker: # Floof
       collection: VulpkaninGekkers
     Squeak: #HL
-      path: /Audio/Animals/fox_squeak.ogg #HL
+      path: /Audio/_DV/Voice/Kitsune/fox_squeal1.ogg #HL
     Yip: #HL
       path: /Audio/_Starlight/Effects/yip.ogg #HL
     Pout: #HL
@@ -377,7 +377,7 @@
     Gekker: # Floof
       collection: VulpkaninGekkers
     Squeak: #HL
-      path: /Audio/Animals/fox_squeak.ogg #HL
+      path: /Audio/_DV/Voice/Kitsune/fox_squeal1.ogg #HL
     Yip: #HL
       path: /Audio/_Starlight/Effects/yip.ogg #HL
     Pout: #HL


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes the kitsune Squeak emote to use the correct sound, currently Squeak and Yip use the same sound. This fixes it so Squeak uses the correct sound from DV.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix
## Technical details
<!-- Summary of code changes for easier review. -->
Switches the sound to /Audio/_DV/Voice/Kitsune/fox_squeal1.ogg instead of /Audio/Animals/fox_squeak.ogg
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Squeak
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Kitsune using the wrong emote sound for squeak.
