### PR TITLE
#1455 fixed protogen surgery

### DIFF
--- a/Resources/Prototypes/_FarHorizons/InventoryTemplates/protogen_inventory_template.yml
+++ b/Resources/Prototypes/_FarHorizons/InventoryTemplates/protogen_inventory_template.yml
@@ -28,7 +28,6 @@
         - ProtogenCybernetics
     - name: outerClothing2
       slotTexture: suit
-      slotFlags: OUTERCLOTHING
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 1,3
@@ -188,7 +187,6 @@
         - ProtogenCybernetics
     - name: outerClothing2
       slotTexture: suit
-      slotFlags: OUTERCLOTHING
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 1,3
@@ -443,7 +441,6 @@
         - ProtogenCybernetics
     - name: outerClothing2
       slotTexture: suit
-      slotFlags: OUTERCLOTHING
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 1,3


### PR DESCRIPTION

## About the PR
Fix for #1455 
The slot the protogen cybernetics were attached to had the slotFlag for OUTERCLOTHING, effectively barring all surgery because that slot was occupied. Simply _removing_ the slotFlag from the slot lets surgery disregard them entirely.

## Why / Balance
Operating on Protogen is important.

## Technical details
removal of the slotFlags of the cybernetics slot in yml

## How to test
* spawn as a protogen
* lie down
* aghost
* get medical multitool
* remove jumpsuit from body
* start operating

## Media
<img width="485" height="743" alt="image" src="https://github.com/user-attachments/assets/20909fef-ef11-47dc-9cb8-f3ed2ef00dac" />



**Changelog**

:cl:
- fix: fixed protogen surgery
