### PR TITLE
Fix Trap Avoider Client/Server Mismatch

### DIFF
--- a/Content.Shared/_Mono/Traits/Physical/TrapAvoiderComponent.cs
+++ b/Content.Shared/_Mono/Traits/Physical/TrapAvoiderComponent.cs
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+using Robust.Shared.GameStates; // HardLight
+
 namespace Content.Shared._Mono.Traits.Physical;
 
 /// <summary>
 /// Step triggers will not activate when this entity steps on them.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent] // HardLight: Added NetworkedComponent
 public sealed partial class TrapAvoiderComponent : Component;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes a client/server mismatch issue that caused characters with the Trap Avoider trait to APPEAR as though they had fallen over, while not actually having fallen over.

I cured seizures.

## Technical details
<!-- Summary of code changes for easier review. -->
Forces the client and server to match.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Characters with the Trap Avoider trait should no longer have seizures when walking on surfaces that would otherwise slip them.

