### PR TITLE
Hard Skin Trait

### DIFF
--- a/Resources/Locale/en-US/_HL/traits/traits.ftl
+++ b/Resources/Locale/en-US/_HL/traits/traits.ftl
@@ -86,3 +86,7 @@ hl-trait-kinky-erotic-moods-desc = Every half hour or so you receive a private r
 
 hl-trait-romantic-moods-name = Romantic Moods
 hl-trait-romantic-moods-desc = Every half hour or so you receive a private reminder of two randomly drawn romantic inclinations — tenderness, dates, closeness. Preferences rotate every one to two and a half hours.
+
+trait-hardskin-name = Hard Skin
+trait-hardskin-desc = Your skin is too hard for needles to pierce.
+injector-component-deny-hardskin = {CAPITALIZE(THE($target))}'s skin is too hard for the needle to pierce.

--- a/Resources/Prototypes/_HL/Traits/Physical.yml
+++ b/Resources/Prototypes/_HL/Traits/Physical.yml
@@ -369,3 +369,20 @@
   - type: Amputee
     removeBodyPart: Arm
     partSymmetry: Right
+
+- type: trait
+  id: HardSkin
+  name: trait-hardskin-name
+  description: trait-hardskin-desc
+  category: Physical
+  cost: -4
+  speciesBlacklist:
+  - IPC
+  - Synth
+  mutuallyExclusiveTraits:
+  - DermalArmor
+  components:
+  - type: BlockInjection
+    blockHypospray: true
+    blockInjectOnProjectile: true
+    blockReason: hardskin

--- a/Resources/Prototypes/_HL/Traits/Physical.yml
+++ b/Resources/Prototypes/_HL/Traits/Physical.yml
@@ -379,8 +379,6 @@
   speciesBlacklist:
   - IPC
   - Synth
-  mutuallyExclusiveTraits:
-  - DermalArmor
   components:
   - type: BlockInjection
     blockHypospray: true

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -313,12 +313,7 @@
   cost: 6
   mutuallyExclusiveTraits:
   - PoolToy
-  - HardSkin # Hardlight
   components:
-  - type: BlockInjection # Hardlight start
-    blockHypospray: true
-    blockInjectOnProjectile: true
-    blockReason: hardskin # Hardlight end
   - type: DamageProtectionBuff
     modifiers:
       dermal:

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -313,7 +313,12 @@
   cost: 6
   mutuallyExclusiveTraits:
   - PoolToy
+  - HardSkin # Hardlight
   components:
+  - type: BlockInjection # Hardlight start
+    blockHypospray: true
+    blockInjectOnProjectile: true
+    blockReason: hardskin # Hardlight end
   - type: DamageProtectionBuff
     modifiers:
       dermal:


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
New trait that prevents injections.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hard Skin gives +4 points. The reason for this is that it is technically a double edged sword - you cannot be injected with poison, BUT you also cannot be injected with any medicine - which slows down your rate of healing.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn as a character with either Hard Skin and see that you cannot be injected.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
:cl: Illumos
- add: Hard Skin trait, gives four points but prevents all injections.