### PR TITLE
Normal bags can no longer be hidden under floor tiles.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseSubfloorAnchorStorage, ClothingBackpack]
+  parent: ClothingBackpack
   id: NFClothingBackpack
   components:
   - type: Storage
@@ -13,7 +13,7 @@
     - 0,0,7,5
 
 - type: entity
-  parent: [BaseSubfloorAnchorStorage, ClothingBackpackDuffel]
+  parent: ClothingBackpackDuffel
   id: NFClothingDuffel
   components:
   - type: Storage


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I removed the component that lets you anchor bags under floor tiles from the base bag prototypes. This means that only the smuggler satchels can be hidden under floors.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Typically, the only bags that you can hide under floor tiles are smuggler's bags, which are thief/traitor items. There's not much point in paying TC to get them, or getting arrested for having them when you can use any bag to accomplish the same things.
## Technical details
<!-- Summary of code changes for easier review. -->
Removed the BaseSubfloorAnchorStorage component from the base NF bag prototypes that every other bag uses.
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn any bag (except for the smuggler's bags, duh) and see that they can't be anchored anymore.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made it so that normal bags can't be hidden under tiles.
