### PR TITLE
Fix Round Transition Forgetting the Previous Round's Occupied Jobs

### DIFF
--- a/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
+++ b/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
@@ -7,6 +7,7 @@ using Content.IntegrationTests.Tests._NF;
 using Content.Server._HL.ColComm;
 using Content.Server.GameTicking;
 using Content.Server._NF.CryoSleep;
+using Content.Server._NF.RoundNotifications.Events;
 using Content.Server._NF.Roles.Systems;
 using Content.Server.Maps;
 using Content.Server.Station.Components;
@@ -821,6 +822,122 @@ public sealed class StationJobsTest
             Assert.That(jobsEvent.StationJobList.TryGetValue(stationNet, out var stationInfo), Is.True);
             Assert.That(stationInfo!.JobsAvailable.TryGetValue("Mercenary", out var lobbySlots), Is.True);
             Assert.That(lobbySlots, Is.EqualTo(0));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test] // HardLight
+    public async Task RoundRestartStationDeletionDoesNotOpenTrackedJobsTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var entitySystemManager = entityManager.EntitySysManager;
+        var stationSystem = entitySystemManager.GetEntitySystem<StationSystem>();
+        var jobTracking = entitySystemManager.GetEntitySystem<JobTrackingSystem>();
+
+        var stationProto = prototypeManager.Index<GameMapPrototype>("FooStation");
+
+        var regularDeletionStation = EntityUid.Invalid;
+        var regularDeletionCrew = EntityUid.Invalid;
+        var restartDeletionStation = EntityUid.Invalid;
+        var restartDeletionCrew = EntityUid.Invalid;
+
+        await server.WaitPost(() =>
+        {
+            regularDeletionStation = stationSystem.InitializeNewStation(stationProto.Stations["Station"], null, "Regular Delete Station");
+            regularDeletionCrew = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+            jobTracking.EnsureTrackedJob(regularDeletionCrew, "TCaptain", regularDeletionStation);
+
+            restartDeletionStation = stationSystem.InitializeNewStation(stationProto.Stations["Station"], null, "Restart Delete Station");
+            restartDeletionCrew = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+            jobTracking.EnsureTrackedJob(restartDeletionCrew, "TCaptain", restartDeletionStation);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitPost(() =>
+        {
+            stationSystem.DeleteStation(regularDeletionStation);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entityManager.EntityExists(regularDeletionCrew), Is.True);
+            Assert.That(entityManager.GetComponent<Content.Shared._NF.Roles.Components.JobTrackingComponent>(regularDeletionCrew).Active, Is.False);
+        });
+
+        await server.WaitPost(() =>
+        {
+            entityManager.EventBus.RaiseEvent(EventSource.Local, new RoundRestartCleanupEvent());
+            stationSystem.DeleteStation(restartDeletionStation);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entityManager.EntityExists(restartDeletionCrew), Is.True);
+            Assert.That(entityManager.GetComponent<Content.Shared._NF.Roles.Components.JobTrackingComponent>(restartDeletionCrew).Active, Is.True);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test] // HardLight
+    public async Task DeletingTrackedBodyReopensStationSlotTest()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var server = pair.Server;
+
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
+        var playerManager = server.ResolveDependency<Robust.Server.Player.IPlayerManager>();
+        var jobTracking = entitySystemManager.GetEntitySystem<JobTrackingSystem>();
+        var mindSystem = entitySystemManager.GetEntitySystem<SharedMindSystem>();
+        var stationJobs = entitySystemManager.GetEntitySystem<StationJobsSystem>();
+        var stationSystem = entitySystemManager.GetEntitySystem<StationSystem>();
+
+        var stationProto = prototypeManager.Index<GameMapPrototype>("FooStation");
+        var serverSession = playerManager.Sessions.Single();
+        var trackedUser = serverSession.UserId;
+
+        var station = EntityUid.Invalid;
+        var trackedCrew = EntityUid.Invalid;
+
+        await server.WaitPost(() =>
+        {
+            station = stationSystem.InitializeNewStation(stationProto.Stations["Station"], null, "Delete Tracked Body Station");
+            trackedCrew = entityManager.SpawnEntity("TestTrackedCrewMob", MapCoordinates.Nullspace);
+
+            jobTracking.EnsureTrackedJob(trackedCrew, "TCaptain", station);
+
+            var mind = mindSystem.CreateMind(trackedUser);
+            mindSystem.TransferTo(mind, trackedCrew, mind: mind);
+            playerManager.SetAttachedEntity(serverSession, trackedCrew);
+
+            Assert.That(stationJobs.TryAssignJob(station, "TCaptain", trackedUser), Is.True);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitPost(() =>
+        {
+            entityManager.DeleteEntity(trackedCrew);
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(stationJobs.IsPlayerJobTracked(station, trackedUser, "TCaptain"), Is.False);
+            Assert.That(stationJobs.TryGetJobSlot(station, "TCaptain", out var slots), Is.True);
+            Assert.That(slots, Is.EqualTo(5));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -3,6 +3,8 @@ using Content.Shared.Administration;
 using Content.Shared.GameTicking;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
+using Content.Server._NF.Roles.Systems; // HardLight
+using Content.Shared._NF.Roles.Components; // HardLight
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
@@ -52,6 +54,9 @@ namespace Content.Server.Ghost
             }
 
             var minds = _entities.System<MindSystem>();
+            if (_entities.TryGetComponent<JobTrackingComponent>(controlled, out var tracking)) // HardLight
+                _entities.System<JobTrackingSystem>().OpenJob((controlled, tracking), player.UserId);
+
             if (minds.TryGetMind(player, out var mindId, out var mind))
                 minds.WipeMind(mindId, mind);
             else

--- a/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
+++ b/Content.Server/_NF/Roles/Systems/JobTrackingSystem.cs
@@ -2,8 +2,11 @@ using Content.Server._NF.CryoSleep;
 using Content.Server._HL.ColComm; // HardLight
 using Content.Server.Afk;
 using Content.Server.GameTicking;
+using Content.Server._NF.RoundNotifications.Events; // HardLight
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Shared.GameTicking; // HardLight
+using Content.Shared.Mind; // HardLight
 using Content.Shared._NF.Roles.Components;
 using Content.Shared._NF.Roles.Systems;
 using Content.Shared.Mind.Components;
@@ -31,6 +34,11 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
     [Dependency] private readonly ColcommJobSystem _colcommJobs = default!; // HardLight
 
+    // HardLight: Round restart deletes all station entities as part of cleanup.
+    // Those deletions should not be treated like a mid-round ship sale/destruction,
+    // or we will mark persisted crew inactive before the next round's slot accounting runs.
+    private bool _suppressStationTerminationRelease;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -39,8 +47,12 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         SubscribeLocalEvent<JobTrackingComponent, CryosleepBeforeMindRemovedEvent>(OnJobBeforeCryoEntered);
         SubscribeLocalEvent<JobTrackingComponent, MindAddedMessage>(OnJobMindAdded);
         SubscribeLocalEvent<JobTrackingComponent, MindRemovedMessage>(OnJobMindRemoved);
+        SubscribeLocalEvent<JobTrackingComponent, EntityTerminatingEvent>(OnTrackedJobTerminating); // HardLight
         SubscribeLocalEvent<ColcommRegistryRoundStartEvent>(OnColcommRegistryRoundStart); // HardLight
+        SubscribeLocalEvent<StationInitializedEvent>(OnStationInitialized); // HardLight
         SubscribeLocalEvent<StationJobsComponent, EntityTerminatingEvent>(OnStationJobsTerminating); // HardLight
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup); // HardLight
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted); // HardLight
     }
 
     /// <summary>
@@ -53,6 +65,9 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
     /// </summary>
     private void OnStationJobsTerminating(Entity<StationJobsComponent> ent, ref EntityTerminatingEvent args)
     {
+        if (_suppressStationTerminationRelease) // HardLight
+            return;
+
         var query = AllEntityQuery<JobTrackingComponent>();
         while (query.MoveNext(out var bodyUid, out var tracking))
         {
@@ -84,6 +99,135 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
 
         if (activeCounts.Count > 0)
             _colcommJobs.DeductActiveRoles(ev.Colcomm, activeCounts);
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev) // HardLight
+    {
+        _suppressStationTerminationRelease = true;
+    }
+
+    private void OnRoundStarted(RoundStartedEvent ev) // HardLight
+    {
+        _suppressStationTerminationRelease = false;
+        RebindCarriedOverTrackedJobs();
+    }
+
+    private void OnTrackedJobTerminating(Entity<JobTrackingComponent> ent, ref EntityTerminatingEvent args) // HardLight
+    {
+        if (!ent.Comp.Active || ent.Comp.Job == null)
+            return;
+
+        OpenJob(ent);
+    }
+
+    // HardLight: When a new station finishes initializing after a round transition, rebind any
+    // active tracked jobs that still point at a deleted prior-round station to this live station.
+    private void OnStationInitialized(StationInitializedEvent ev)
+    {
+        if (!TryComp<StationJobsComponent>(ev.Station, out var stationJobs))
+            return;
+
+        var query = AllEntityQuery<JobTrackingComponent>();
+        while (query.MoveNext(out var uid, out var tracking))
+        {
+            if (!tracking.Active
+                || tracking.Job is not { } job
+                || (!Deleted(tracking.SpawnStation) && HasComp<StationJobsComponent>(tracking.SpawnStation)))
+            {
+                continue;
+            }
+
+            var stationJob = _stationJobs.GetStationTrackingJobId(ev.Station, job, stationJobs);
+            if (!_stationJobs.IsConfiguredJob(ev.Station, stationJob, stationJobs))
+                continue;
+
+            tracking.SpawnStation = ev.Station;
+            Dirty(uid, tracking);
+        }
+    }
+
+    // HardLight: On round start, normalize carried-over tracked jobs onto a live configured
+    // station so later close/open operations do not keep referencing deleted round entities.
+    private void RebindCarriedOverTrackedJobs()
+    {
+        var query = AllEntityQuery<JobTrackingComponent>();
+        while (query.MoveNext(out var uid, out var tracking))
+        {
+            if (!tracking.Active || tracking.Job is not { } job)
+                continue;
+
+            var reboundStation = ResolveTrackedStation(tracking.SpawnStation, job);
+            if (reboundStation == tracking.SpawnStation)
+                continue;
+
+            tracking.SpawnStation = reboundStation;
+            Dirty(uid, tracking);
+        }
+    }
+
+    // HardLight: Resolve the live station that should own a carried-over tracked job when its
+    // original station entity no longer exists after restart cleanup.
+    private EntityUid ResolveTrackedStation(EntityUid spawnStation, ProtoId<JobPrototype> job)
+    {
+        if (!Deleted(spawnStation) && HasComp<StationJobsComponent>(spawnStation))
+            return spawnStation;
+
+        EntityUid? defaultMapStation = null;
+        EntityUid? nonShipStation = null;
+        EntityUid? fallbackStation = null;
+        var stationQuery = EntityQueryEnumerator<StationJobsComponent>();
+        while (stationQuery.MoveNext(out var stationUid, out var stationJobs))
+        {
+            var stationJob = _stationJobs.GetStationTrackingJobId(stationUid, job, stationJobs);
+            if (!_stationJobs.IsConfiguredJob(stationUid, stationJob, stationJobs))
+                continue;
+
+            if (IsStationOnDefaultMap(stationUid))
+                defaultMapStation = stationUid;
+
+            if (!_stationJobs.IsShipCrewHiringStation(stationUid))
+                nonShipStation = stationUid;
+
+            fallbackStation = stationUid;
+        }
+
+        return defaultMapStation
+            ?? nonShipStation
+            ?? fallbackStation
+            ?? spawnStation;
+    }
+
+    private bool IsStationOnDefaultMap(EntityUid stationUid) // HardLight
+    {
+        if (!TryComp<StationDataComponent>(stationUid, out var stationData))
+            return false;
+
+        foreach (var gridUid in stationData.Grids)
+        {
+            if (Deleted(gridUid) || !TryComp<TransformComponent>(gridUid, out var xform))
+                continue;
+
+            if (xform.MapID == _gameTicker.DefaultMap)
+                return true;
+        }
+
+        return false;
+    }
+
+    private List<(EntityUid Station, StationJobsComponent Jobs, ProtoId<JobPrototype> StationJob)> GetMatchingTrackedStations(ProtoId<JobPrototype> job) // HardLight
+    {
+        var stations = new List<(EntityUid, StationJobsComponent, ProtoId<JobPrototype>)>();
+        var query = EntityQueryEnumerator<StationJobsComponent>();
+        while (query.MoveNext(out var stationUid, out var stationJobs))
+        {
+            var stationJob = _stationJobs.GetStationTrackingJobId(stationUid, job, stationJobs);
+            if (!_stationJobs.IsConfiguredJob(stationUid, stationJob, stationJobs))
+                continue;
+
+            stations.Add((stationUid, stationJobs, stationJob));
+        }
+
+        return stations;
     }
 
     // HardLight: If a player returns to their body (or an admin forces a mind in), consume a
@@ -138,18 +282,52 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
         ent.Comp.Active = false;
         RaiseLocalEvent(new JobTrackingStateChangedEvent()); // HardLight
 
-        TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs);
-        var stationJob = _stationJobs.GetStationTrackingJobId(ent.Comp.SpawnStation, job, stationJobs);
+        // HardLight start
+        var originalSpawnStation = ent.Comp.SpawnStation;
+        StationJobsComponent? originalStationJobs = null;
+        var hadLiveSpawnStation = !Deleted(originalSpawnStation)
+            && TryComp(originalSpawnStation, out originalStationJobs);
+
+        var spawnStation = ResolveTrackedStation(originalSpawnStation, job);
+        if (spawnStation != ent.Comp.SpawnStation)
+        {
+            ent.Comp.SpawnStation = spawnStation;
+            Dirty(ent, ent.Comp);
+        }
+
+        var stationTargets = new List<(EntityUid Station, StationJobsComponent Jobs, ProtoId<JobPrototype> StationJob)>();
+        if (hadLiveSpawnStation)
+        {
+            stationTargets.Add((originalSpawnStation, originalStationJobs!, _stationJobs.GetStationTrackingJobId(originalSpawnStation, job, originalStationJobs)));
+        }
+        else
+        {
+            stationTargets = GetMatchingTrackedStations(job);
+        }
+        // HardLight end
 
         NetUserId? trackedUserId = userId;
         if (trackedUserId == null && _player.TryGetSessionByEntity(ent, out var session))
             trackedUserId = session.UserId;
 
-        if (trackedUserId != null && stationJobs != null)
-            _stationJobs.TryUntrackPlayerJob(ent.Comp.SpawnStation, trackedUserId.Value, stationJob, stationJobs);
+        // HardLight start
+        if (trackedUserId == null
+            && TryComp<MindContainerComponent>(ent, out var mindContainer)
+            && mindContainer.Mind is { } mindUid
+            && TryComp<MindComponent>(mindUid, out var mind)
+            && mind.UserId is { } mindUserId)
+        {
+            trackedUserId = mindUserId;
+        }
 
-        if (stationJobs != null)
-            _stationJobs.TryReopenTrackedJobSlot(ent.Comp.SpawnStation, stationJob, stationJobs);
+        foreach (var (stationUid, jobs, stationJob) in stationTargets)
+        {
+            if (trackedUserId != null)
+                _stationJobs.TryUntrackPlayerJob(stationUid, trackedUserId.Value, stationJob, jobs);
+
+            _stationJobs.TryReopenTrackedJobSlot(stationUid, stationJob, jobs);
+        }
+        // HardLight end
 
         var colcommJob = _stationJobs.GetColcommJobId(job);
 
@@ -190,18 +368,25 @@ public sealed class JobTrackingSystem : SharedJobTrackingSystem
             RaiseLocalEvent(new JobTrackingStateChangedEvent());
         }
 
-        if (!ShouldReopenTrackedJob(ent.Comp.SpawnStation, job))
+        var spawnStation = ResolveTrackedStation(ent.Comp.SpawnStation, job);
+        if (spawnStation != ent.Comp.SpawnStation)
+        {
+            ent.Comp.SpawnStation = spawnStation;
+            Dirty(ent, ent.Comp);
+        }
+
+        if (!ShouldReopenTrackedJob(spawnStation, job))
             return;
 
-        var stationJob = _stationJobs.GetStationTrackingJobId(ent.Comp.SpawnStation, job);
+        var stationJob = _stationJobs.GetStationTrackingJobId(spawnStation, job);
 
-        if (TryComp<StationJobsComponent>(ent.Comp.SpawnStation, out var stationJobs)
-            && !_stationJobs.IsPlayerJobTracked(ent.Comp.SpawnStation, userId, stationJob, stationJobs))
+        if (TryComp<StationJobsComponent>(spawnStation, out var stationJobs)
+            && !_stationJobs.IsPlayerJobTracked(spawnStation, userId, stationJob, stationJobs))
         {
-            if (_stationJobs.TryGetJobSlot(ent.Comp.SpawnStation, stationJob, out var localSlots) && localSlots > 0)
-                _stationJobs.TryAdjustJobSlot(ent.Comp.SpawnStation, stationJob, -1, clamp: true, stationJobs: stationJobs);
+            if (_stationJobs.TryGetJobSlot(spawnStation, stationJob, out var localSlots) && localSlots > 0)
+                _stationJobs.TryAdjustJobSlot(spawnStation, stationJob, -1, clamp: true, stationJobs: stationJobs);
 
-            _stationJobs.TryTrackPlayerJob(ent.Comp.SpawnStation, userId, stationJob, stationJobs);
+            _stationJobs.TryTrackPlayerJob(spawnStation, userId, stationJob, stationJobs);
         }
 
         var colcommJob = _stationJobs.GetColcommJobId(job);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes what may be the final bug with dynamic job allocation. Previously, ending a round caused the system to essentially reset, meaning occupied slots from the previous round(s) didn't correctly carry over into the next round.

More specifically, any job with a set number of allocated slots failed to remember slots that were occupied from previous rounds, so if a Captain carried over to the next round, there would still be an open slot for a Captain because the server forgot there was already an active Captain. Only people who joined that round were counted towards the allocation system, instead of people persisting from previous rounds.

Now, if a Captain carries over to the next round, there should be no open Captain slots until the previous round's Captain no longer exists.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Specifically requested by Fenn. It's also a bug fix...

## Technical details
<!-- Summary of code changes for easier review. -->
I'm not 100% confident in what I've done here, and that may just be due to the past three failures in trying to achieve the same thing, but I WAS able to test it, extensively even, and it DOES seem to work. 

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
It's a bit complicated to test, and requires multiple open clients. I'll keep it short and say open three clients, have one join as a Janitor and one as a Freelancer. End the round. Restart the round. Start the round. Have the third client confirm that the new station only has 3 out of 4 Janitor slots open and 0 Freelancer slots open. /ghost with the Janitor client. Observe that Janitor slots repopulate to 4 out of 4. Join as a Janitor AGAIN and observe that a new Freelancer slot doesn't open.

You can further test by /ghost'ing the Freelancer and a new Freelancer slot should then open like normal. I didn't personally test that, but it should work still.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
It remains to be seen.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Dynamic job slot allocation should finally work as intended.
