### PR TITLE
Fix Additional Modular Console Sprite Issues

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -14,13 +14,6 @@
       state: detective_television
   - type: Computer
     board: ComputerTelevisionCircuitboard
-  # Starlight start
-  - type: GenericVisualizer  # Override to prevent edge connection sprites
-    visuals:
-      enum.EdgeConnectionVisuals.ConnectionMask:
-        console:
-          None: { state: television}
-  # Starlight end
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -43,6 +36,9 @@
   name: telescreen frame
   description: Finally, some decent reception around here...
   components:
+  - type: EdgeConnection # HardLight
+    connectionKey: wallmount_computers
+    allowedDirections: East, West
   - type: Construction
     graph: WallmountTelescreen
     node: TelescreenFrame
@@ -54,6 +50,16 @@
         state: telescreen_frame
       - map: ["computerLayerScreen"]
         state: telescreen
+  # HardLight start
+  - type: GenericVisualizer
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: telescreen_frame, sprite: Structures/Machines/computers.rsi }
+          West: { state: telescreen_frame, sprite: Structures/Machines/computers.rsi }
+          East: { state: telescreen_frame, sprite: Structures/Machines/computers.rsi }
+          East, West: { state: telescreen_frame, sprite: Structures/Machines/computers.rsi }
+  # HardLight end
   # Frontier: remove fixtures, it's a wallmount device
   # - type: Fixtures
   #   fixtures:
@@ -156,6 +162,16 @@
         state: television_wall
       - map: ["computerLayerScreen"]
         state: television_wallscreen
+  # HardLight start
+  - type: GenericVisualizer
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: television_wall, sprite: Structures/Wallmounts/flatscreentv.rsi }
+          West: { state: television_wall, sprite: Structures/Wallmounts/flatscreentv.rsi }
+          East: { state: television_wall, sprite: Structures/Wallmounts/flatscreentv.rsi }
+          East, West: { state: television_wall, sprite: Structures/Wallmounts/flatscreentv.rsi }
+  # HardLight end
 
 - type: entity
   parent: WallmountTelevisionFrame

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
@@ -44,14 +44,17 @@
     mode: SnapgridCenter
   components:
     - type: StationMap
+    - type: EdgeConnection # HardLight
+      connectionKey: wallmount_computers
+      allowedDirections: East, West
     - type: Transform
       anchored: true
     - type: Sprite
       sprite: Structures/Machines/station_map.rsi
       layers:
-      - map: ["computerLayerBody"]
+      - map: [ "computerLayerBody" ]
         state: station_map0
-      - map: ["computerLayerScreen"]
+      - map: [ "computerLayerScreen" ]
         state: unshaded
     # HardLight start
     - type: GenericVisualizer

--- a/Resources/Prototypes/_NF/Entities/Structures/atm.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/atm.yml
@@ -3,6 +3,9 @@
   parent: BaseComputer
   abstract: true
   components:
+  - type: EdgeConnection # HardLight
+    connectionKey: atm_computers
+    allowedDirections: East, West
   - type: ActivatableUIRequiresPower
   - type: ActivatableUI
     singleUser: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes telescreens and wallmount televisions attempting to use console frame sprites, and fixes ATMs and telescreens triggering console edge-connection sprites.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed telescreens and televisions appearing with normal console frames.
- fix: Fixed ATMs and telescreens triggering modular console edge-connection sprites.
