### PR TITLE
Disable unrevivable and blindness mutations

### DIFF
--- a/Resources/Prototypes/_Funkystation/Genetics/genetic_mutations.yml
+++ b/Resources/Prototypes/_Funkystation/Genetics/genetic_mutations.yml
@@ -909,33 +909,33 @@
     reagents:
       - Mutadone
 
-- type: geneticMutation
-  id: SevereMyopia
-  name: "Severe Myopia"
-  desc: "Subject has terrible eyesight."
-  popupText: "Everything gets a little blurry"
-  instability: -10
-  components:
-  - type: PermanentBlindness # TODO: Make system to ensure and set PermanentBlindness component instead.
-    blindness: 4
+# - type: geneticMutation # Hardlight: These don't seem to work with mutadone? Disabling until a fix is found.
+#   id: SevereMyopia
+#   name: "Severe Myopia"
+#   desc: "Subject has terrible eyesight."
+#   popupText: "Everything gets a little blurry"
+#   instability: -10
+#   components:
+#   - type: PermanentBlindness # TODO: Make system to ensure and set PermanentBlindness component instead.
+#     blindness: 4
+#
+# - type: geneticMutation
+#   id: Blindness
+#   name: "Total Blindness"
+#   desc: "Subject is completely blind."
+#   popupText: "You can't see a thing"
+#   instability: -20
+#   components:
+#   - type: PermanentBlindness # TODO: Make system to ensure and set PermanentBlindness component instead.
 
-- type: geneticMutation
-  id: Blindness
-  name: "Total Blindness"
-  desc: "Subject is completely blind."
-  popupText: "You can't see a thing"
-  instability: -20
-  components:
-  - type: PermanentBlindness # TODO: Make system to ensure and set PermanentBlindness component instead.
-
-- type: geneticMutation
-  id: Unrevivable
-  name: "Do Not Resuscitate"
-  desc: "Subject cannot be revived by any means. Death is permanent."
-  popupText: "You feel your mortality"
-  instability: -20
-  components:
-  - type: Unrevivable
+# - type: geneticMutation # Hardlight: Overly punishing
+#   id: Unrevivable
+#   name: "Do Not Resuscitate"
+#   desc: "Subject cannot be revived by any means. Death is permanent."
+#   popupText: "You feel your mortality"
+#   instability: -20
+#   components:
+#   - type: Unrevivable
 
 - type: geneticMutation
   id: BloodToxification


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Blindness mutations seem bugged and are not fixable with mutadone.
Also, Unrevivable is an insane trait to just get hit with as a random mutation. It's probably less punishing on Funky, where rounds are like 2 hours or something and has no persistence. But uh.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- remove: Blindness mutation is now disabled.
- remove: DNR mutation is now disabled.