### PR TITLE
Make Command Bounties Require Basic Command Access

### DIFF
--- a/Resources/Prototypes/_NF/bounty_contract_collections.yml
+++ b/Resources/Prototypes/_NF/bounty_contract_collections.yml
@@ -4,11 +4,17 @@
   notificationType: Radio
   name: bounty-contract-collection-name-command
   writeAccess:
-  - HeadOfPersonnel
-  - HeadOfSecurity
+  - Command # HardLight
+  # HardLight start: Why were command bounties restricted to specific command members?
+  # - HeadOfPersonnel
+  # - HeadOfSecurity
+  # HardLight end
   deleteAccess:
-  - HeadOfPersonnel
-  - HeadOfSecurity
+  - Command # HardLight
+  # HardLight start: Why were command bounties restricted to specific command members?
+  # - HeadOfPersonnel
+  # - HeadOfSecurity
+  # HardLight end
   categories:
   - Criminal
   - Vacancy


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Why the fuck does all of Command not have the ability to make COMMAND bounties?

## Technical details
<!-- Summary of code changes for easier review. -->
Changes command bounties to only require Command access, instead of specifically HeadOfPersonnel or HeadOfSecurity.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: All members of Command can now issue command bounties.
