### PR TITLE
Various fixes to apartments system

### DIFF
--- a/Content.Client/_HL/Rooms/RoomGridFileManagementSystem.cs
+++ b/Content.Client/_HL/Rooms/RoomGridFileManagementSystem.cs
@@ -4,6 +4,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using System;
+using System.Threading.Tasks;
 
 namespace Content.Client._HL.Rooms;
 
@@ -55,17 +56,23 @@ public sealed class RoomGridFileManagementSystem : EntitySystem
     {
         var safeKey = SanitizeKey(message.CharacterKey);
         var filePath = GetRoomGridPath(safeKey);
+        var roomData = message.RoomData;
 
-        try
+        // Write on a background thread so the game thread isn't blocked by disk I/O.
+        // We don't need the result; logging handles failures.
+        Task.Run(() =>
         {
-            _resourceManager.UserData.CreateDir(new(RoomGridsRoot));
-            using var writer = _resourceManager.UserData.OpenWriteText(new(filePath));
-            writer.Write(message.RoomData);
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"Failed to save room data to {filePath}: {ex.Message}");
-        }
+            try
+            {
+                _resourceManager.UserData.CreateDir(new(RoomGridsRoot));
+                using var writer = _resourceManager.UserData.OpenWriteText(new(filePath));
+                writer.Write(roomData);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to save room data to {filePath}: {ex.Message}");
+            }
+        });
     }
 
     private static string GetRoomGridPath(string safeKey)

--- a/Content.Server/Shuttles/ShipSerializationSystem.cs
+++ b/Content.Server/Shuttles/ShipSerializationSystem.cs
@@ -51,6 +51,19 @@ using Robust.Shared.EntitySerialization.Systems; // Added for MapLoaderSystem
 using Robust.Shared.EntitySerialization;
 using Content.Shared.Access.Components; // AccessReaderComponent for access retention
 using Robust.Shared.Map.Events; // For BeforeEntityReadEvent
+using Content.Server.Construction;
+using Content.Server.Construction.Components;
+using Content.Shared.SprayPainter.Components;
+using Content.Shared.SprayPainter.Prototypes;
+using Content.Shared.Materials;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Prototypes;
+using Content.Shared.Paint;
+using Content.Shared.Labels.Components;
+using Content.Shared.Labels.EntitySystems;
+using Content.Shared.Sprite;
+using Content.Shared.Tag;
 
 namespace Content.Server.Shuttles.Save
 {
@@ -71,6 +84,13 @@ namespace Content.Server.Shuttles.Save
         [Dependency] private readonly IGameTiming _gameManager = default!;
         [Dependency] private readonly MapLoaderSystem _mapLoader = default!; // For refactored serializer path
         [Dependency] private readonly IDependencyCollection _dependencyCollection = default!; // Use same dependency collection as MapLoaderSystem
+        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
+        [Dependency] private readonly SharedStorageSystem _storageSystem = default!;
+        [Dependency] private readonly SharedStackSystem _stackSystem = default!;
+        [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
+        [Dependency] private readonly LabelSystem _labelSystem = default!;
+        [Dependency] private readonly TagSystem _tagSystem = default!;
         // Note: For EntityDeserializer we use IoCManager.Instance directly to avoid extra injected fields.
 
         private ISawmill _sawmill = default!;
@@ -450,10 +470,10 @@ namespace Content.Server.Shuttles.Save
             }
         }
 
-        public ShipGridData SerializeShipArea(EntityUid gridId, NetUserId playerId, string shipName, Box2 bounds, HashSet<EntityUid>? excludeEntities = null)
+        public ShipGridData SerializeShipArea(EntityUid gridId, NetUserId playerId, string shipName, Box2 bounds, HashSet<EntityUid>? excludeEntities = null, bool includeVendors = false)
         {
             var verbose = _configManager.GetCVar(Content.Shared.CCVar.CCVars.ShipyardSaveVerbose);
-            var excludeVending = _configManager.GetCVar(Content.Shared.HL.CCVar.HLCCVars.ExcludeVendingInShipSave);
+            var excludeVending = !includeVendors && _configManager.GetCVar(Content.Shared.HL.CCVar.HLCCVars.ExcludeVendingInShipSave);
 
             if (!_entityManager.TryGetComponent<MapGridComponent>(gridId, out var grid))
                 throw new ArgumentException($"Grid with ID {gridId} not found.");
@@ -529,6 +549,12 @@ namespace Content.Server.Shuttles.Save
                     if (!bounds.Contains(childTransform.LocalPosition))
                         continue;
 
+                    // Skip mobs and player-minded entities
+                    if (_entityManager.HasComponent<Content.Shared.Mobs.Components.MobStateComponent>(childUid))
+                        continue;
+                    if (_entityManager.HasComponent<Content.Shared.Mind.Components.MindContainerComponent>(childUid))
+                        continue;
+
                     var meta = _entityManager.GetComponentOrNull<MetaDataComponent>(childUid);
                     var proto = meta?.EntityPrototype?.ID ?? string.Empty;
                     if (string.IsNullOrEmpty(proto))
@@ -537,7 +563,7 @@ namespace Content.Server.Shuttles.Save
                     if (excludeVending && _entityManager.HasComponent<VendingMachineComponent>(childUid))
                         continue;
 
-                    var entityData = SerializeEntity(childUid, childTransform, proto, gridId);
+                    var entityData = SerializeEntity(childUid, childTransform, proto, gridId, roomMode: true);
                     if (entityData != null)
                     {
                         gridData.Entities.Add(entityData);
@@ -545,9 +571,8 @@ namespace Content.Server.Shuttles.Save
                     }
                 }
 
-                // Second pass: unanchored loose items within bounds (plushies, pillows, buttons,
-                // bed sheets, etc.). Exclude mobs/players and items already in containers;
-                // SerializeContainedEntities will handle those.
+                // Second pass: unanchored loose items with the RoomSaveable tag (plushies, pillows,
+                // potted plants, etc.). Tools and gameplay items without the tag are excluded.
                 var childEnumerator2 = gridTransform.ChildEnumerator;
                 while (childEnumerator2.MoveNext(out var childUid2))
                 {
@@ -589,7 +614,12 @@ namespace Content.Server.Shuttles.Save
                     if (excludeVending && _entityManager.HasComponent<VendingMachineComponent>(childUid2))
                         continue;
 
-                    var entityData2 = SerializeEntity(childUid2, childTransform2, proto2, gridId);
+                    // Only save unanchored items explicitly tagged for room preservation.
+                    // Gameplay items (tools, weapons, spray painters, etc.) lack this tag and are dropped.
+                    if (!_tagSystem.HasTag(childUid2, "RoomSaveable"))
+                        continue;
+
+                    var entityData2 = SerializeEntity(childUid2, childTransform2, proto2, gridId, roomMode: true);
                     if (entityData2 != null)
                     {
                         gridData.Entities.Add(entityData2);
@@ -599,8 +629,23 @@ namespace Content.Server.Shuttles.Save
                     }
                 }
 
-                SerializeContainedEntities(gridId, gridData, serializedEntities);
+                SerializeContainedEntities(gridId, gridData, serializedEntities, includeVendors, roomMode: true);
                 ValidateContainerRelationships(gridData);
+
+                // Room-specific: append Properties-based component data for types the generic
+                // DataNode path can't round-trip (spray paint, material silos, storage positions).
+                foreach (var entityData in gridData.Entities)
+                {
+                    if (EntityUid.TryParse(entityData.EntityId, out var entityUid))
+                        AddRoomComponentData(entityUid, entityData);
+                }
+
+                // Drop component entries with empty Properties — these came from the generic
+                // SerializeComponent path which writes bloated DataNode YAML (unusable on load).
+                // Room restores use Properties-based paths only; empty-Properties entries are no-ops.
+                // Effect: ~4 MB room save shrinks to ~50 KB.
+                foreach (var entityData in gridData.Entities)
+                    entityData.Components.RemoveAll(c => !c.Properties.Any());
 
                 shipGridData.Grids.Add(gridData);
 
@@ -1475,6 +1520,7 @@ namespace Content.Server.Shuttles.Save
                     var newEntity = SpawnEntityWithComponents(entityData, coords, clearDefaultsForContainers: false);
                     if (newEntity != null)
                     {
+                        RestoreRoomComponents(newEntity.Value, entityData);
                         entityIdMapping[entityData.EntityId] = newEntity.Value;
                         // Room saves filter to Anchored-only entities, but the serialized
                         // TransformComponent is intentionally skipped. Re-anchor here so
@@ -1483,6 +1529,8 @@ namespace Content.Server.Shuttles.Save
                     }
                 }
 
+                RestoreStorageLocations(primaryGridData.Entities, entityIdMapping);
+                RefreshRoomMachines(primaryGridData.Entities, entityIdMapping);
                 return;
             }
 
@@ -1509,6 +1557,7 @@ namespace Content.Server.Shuttles.Save
                 var newEntity = SpawnEntityWithComponents(entityData, coords, clearDefaultsForContainers: true);
                 if (newEntity != null)
                 {
+                    RestoreRoomComponents(newEntity.Value, entityData);
                     entityIdMapping[entityData.EntityId] = newEntity.Value;
                     // Room saves filter to Anchored-only entities at the top level; re-anchor
                     // since the serialized TransformComponent (and thus its Anchored flag) is skipped.
@@ -1523,6 +1572,7 @@ namespace Content.Server.Shuttles.Save
                 if (containedEntity == null)
                     continue;
 
+                RestoreRoomComponents(containedEntity.Value, entityData);
                 entityIdMapping[entityData.EntityId] = containedEntity.Value;
 
                 if (!string.IsNullOrEmpty(entityData.ParentContainerEntity) &&
@@ -1541,6 +1591,9 @@ namespace Content.Server.Shuttles.Save
                     entityIdMapping.Remove(entityData.EntityId);
                 }
             }
+
+            RestoreStorageLocations(primaryGridData.Entities, entityIdMapping);
+            RefreshRoomMachines(primaryGridData.Entities, entityIdMapping);
         }
 
         public EntityUid ReconstructShip(ShipGridData shipGridData)
@@ -1788,7 +1841,13 @@ namespace Content.Server.Shuttles.Save
             }
         }
 
-        private List<ComponentData> SerializeEntityComponents(EntityUid entityUid)
+        /// <param name="roomMode">
+        /// When true, skips the generic <see cref="SerializeComponent"/> path (which calls
+        /// <c>_serializationManager.WriteValue</c> on every component via expensive reflection,
+        /// then discards the output). Room saves use Properties-based paths only; the generic
+        /// DataNode round-trip is broken for rooms and produces only bloat.
+        /// </param>
+        private List<ComponentData> SerializeEntityComponents(EntityUid entityUid, bool roomMode = false)
         {
             var componentDataList = new List<ComponentData>();
 
@@ -1809,6 +1868,14 @@ namespace Content.Server.Shuttles.Save
                         if (component is SolutionContainerManagerComponent solutionManager)
                         {
                             componentData = SerializeSolutionComponent(entityUid, solutionManager);
+                        }
+                        else if (roomMode)
+                        {
+                            // Room saves: skip the generic write path entirely. It calls
+                            // _serializationManager.WriteValue ~8000 times per save and produces
+                            // DataNode YAML that can't round-trip. AddRoomComponentData handles
+                            // every component type rooms actually need to restore.
+                            continue;
                         }
                         else if (component is SolutionComponent solutionComp
                                  && !float.IsFinite(solutionComp.Solution.Temperature))
@@ -1935,8 +2002,12 @@ namespace Content.Server.Shuttles.Save
                 "RadioComponent", "InteractionOutlineComponent",
                 // Scan-only
                 "SolutionScannerComponent",
-                // Safety: still skip vending machines entirely if flagged elsewhere
-                "VendingMachineComponent"
+                // Runtime-only: mirrored from ShipSaveYamlSanitizer.FilteredTypes
+                "JointComponent", "NavMapComponent", "DockingComponent", "ActionGrantComponent",
+                "ForensicsComponent", "ContainmentFieldGeneratorComponent",
+                "LinkedLifecycleGridParentComponent", "ShuttleDeedComponent", "IFFComponent",
+                "StationMemberComponent", "BlockingComponent", "TurnstileComponent",
+                "SubdermalImplantComponent", "ProjectileComponent", "ItemToggleActiveSoundComponent",
             };
 
             return problematicTypes.Contains(typeName);
@@ -2020,12 +2091,12 @@ namespace Content.Server.Shuttles.Save
                         : Atmospherics.T20C;
                     var solutionInfo = new Dictionary<string, object>
                     {
-                        ["Volume"] = solution.Volume,
-                        ["MaxVolume"] = solution.MaxVolume,
+                        ["Volume"] = solution.Volume.Double(),
+                        ["MaxVolume"] = solution.MaxVolume.Double(),
                         ["Temperature"] = safeTemperature,
                         ["Reagents"] = solution.Contents?.ToDictionary(
                             reagent => reagent.Reagent.Prototype,
-                            reagent => (object)reagent.Quantity
+                            reagent => (object)reagent.Quantity.Double()
                         ) ?? new Dictionary<string, object>()
                     };
                     solutionData[solutionName] = solutionInfo;
@@ -2048,6 +2119,392 @@ namespace Content.Server.Shuttles.Save
             }
         }
 
+
+        private void AddRoomComponentData(EntityUid uid, EntityData entityData)
+        {
+            if (_entityManager.TryGetComponent<SprayPaintedComponent>(uid, out var sprayPainted))
+            {
+                var d = SerializeSprayPaintedComponent(sprayPainted);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<MaterialStorageComponent>(uid, out var materialStorage))
+            {
+                var d = SerializeMaterialStorageComponent(materialStorage);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<StorageComponent>(uid, out var storageComp))
+            {
+                var d = SerializeStorageLocationsComponent(uid, storageComp);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<StackComponent>(uid, out var stack))
+            {
+                var d = SerializeStackComponent(stack);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<PaintedComponent>(uid, out var painted))
+            {
+                var d = SerializePaintedComponent(painted);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<LabelComponent>(uid, out var label))
+            {
+                var d = SerializeLabelComponent(label);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<PaperComponent>(uid, out var paper))
+            {
+                var d = SerializePaperComponent(paper);
+                if (d != null) entityData.Components.Add(d);
+            }
+            if (_entityManager.TryGetComponent<RandomSpriteComponent>(uid, out var randomSprite))
+            {
+                var d = SerializeRandomSpriteComponent(randomSprite);
+                if (d != null) entityData.Components.Add(d);
+            }
+        }
+
+        private void RestoreRoomComponents(EntityUid uid, EntityData entityData)
+        {
+            foreach (var componentData in entityData.Components)
+            {
+                if (componentData.Type == "SprayPaintedComponent" && componentData.Properties.Any())
+                    RestoreSprayPaintedComponent(uid, componentData);
+                else if (componentData.Type == "MaterialStorageComponent" && componentData.Properties.Any())
+                    RestoreMaterialStorageComponent(uid, componentData);
+                else if (componentData.Type == "StackComponent" && componentData.Properties.Any())
+                    RestoreStackComponent(uid, componentData);
+                else if (componentData.Type == "PaintedComponent" && componentData.Properties.Any())
+                    RestorePaintedComponent(uid, componentData);
+                else if (componentData.Type == "LabelComponent" && componentData.Properties.Any())
+                    RestoreLabelComponent(uid, componentData);
+                else if (componentData.Type == "PaperComponent" && componentData.Properties.Any())
+                    RestorePaperComponent(uid, componentData);
+                else if (componentData.Type == "RandomSpriteComponent" && componentData.Properties.Any())
+                    RestoreRandomSpriteComponent(uid, componentData);
+                // StorageComponent locations handled in RestoreStorageLocations post-pass
+            }
+        }
+
+        private ComponentData? SerializeSprayPaintedComponent(SprayPaintedComponent comp)
+        {
+            if (string.IsNullOrEmpty(comp.PaintedPrototype))
+                return null;
+            return new ComponentData
+            {
+                Type = "SprayPaintedComponent",
+                Properties = new Dictionary<string, object> { ["PaintedPrototype"] = comp.PaintedPrototype },
+            };
+        }
+
+        private void RestoreSprayPaintedComponent(EntityUid entityUid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("PaintedPrototype", out var protoObj))
+                return;
+            var proto = protoObj?.ToString();
+            if (string.IsNullOrEmpty(proto))
+                return;
+            var comp = EnsureComp<SprayPaintedComponent>(entityUid);
+            comp.PaintedPrototype = proto;
+            Dirty(entityUid, comp);
+            // ComponentStartup already fired when the entity was spawned; re-apply appearance manually.
+            _appearance.SetData(entityUid, PaintableVisuals.Prototype, proto);
+        }
+
+        private ComponentData? SerializeMaterialStorageComponent(MaterialStorageComponent comp)
+        {
+            if (comp.Storage.Count == 0)
+                return null;
+            var materials = comp.Storage.ToDictionary(
+                kv => kv.Key.Id,
+                kv => (object)kv.Value);
+            return new ComponentData
+            {
+                Type = "MaterialStorageComponent",
+                Properties = new Dictionary<string, object> { ["Materials"] = materials },
+            };
+        }
+
+        private void RestoreMaterialStorageComponent(EntityUid entityUid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("Materials", out var materialsObj))
+                return;
+            var materials = CoerceToDictStringObj(materialsObj);
+            if (materials == null)
+                return;
+            foreach (var (matId, amountObj) in materials)
+            {
+                if (!int.TryParse(amountObj?.ToString(), out var amount) || amount <= 0)
+                    continue;
+                _materialStorage.TrySetMaterialAmount(entityUid, matId, amount);
+            }
+        }
+
+        private void RefreshRoomMachines(List<EntityData> entityDataList, Dictionary<string, EntityUid> idMap)
+        {
+            foreach (var entityData in entityDataList)
+            {
+                if (entityData.IsContained)
+                    continue;
+                if (!idMap.TryGetValue(entityData.EntityId, out var uid))
+                    continue;
+                if (!_entityManager.TryGetComponent<MachineComponent>(uid, out var machine))
+                    continue;
+                _constructionSystem.RefreshParts(uid, machine);
+            }
+        }
+
+
+        private ComponentData? SerializeStackComponent(StackComponent stack)
+        {
+            return new ComponentData
+            {
+                Type = "StackComponent",
+                Properties = new Dictionary<string, object> { ["Count"] = stack.Count },
+            };
+        }
+
+        private void RestoreStackComponent(EntityUid entityUid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("Count", out var countObj))
+                return;
+            if (!int.TryParse(countObj?.ToString(), out var count) || count <= 0)
+                return;
+            _stackSystem.SetCount(entityUid, count);
+        }
+
+        private ComponentData? SerializePaintedComponent(PaintedComponent comp)
+        {
+            if (!comp.Enabled)
+                return null;
+            return new ComponentData
+            {
+                Type = "PaintedComponent",
+                Properties = new Dictionary<string, object>
+                {
+                    ["Color"] = comp.Color.ToHex(),
+                    ["Enabled"] = (object)comp.Enabled,
+                    ["ShaderName"] = comp.ShaderName,
+                },
+            };
+        }
+
+        private void RestorePaintedComponent(EntityUid uid, ComponentData componentData)
+        {
+            var comp = EnsureComp<PaintedComponent>(uid);
+            if (componentData.Properties.TryGetValue("Color", out var colorObj) && colorObj is string hex)
+                comp.Color = Color.FromHex(hex);
+            if (componentData.Properties.TryGetValue("Enabled", out var enabledObj)
+                && bool.TryParse(enabledObj?.ToString(), out var enabled))
+                comp.Enabled = enabled;
+            if (componentData.Properties.TryGetValue("ShaderName", out var shaderObj) && shaderObj is string shader)
+                comp.ShaderName = shader;
+            Dirty(uid, comp);
+            _appearance.SetData(uid, PaintVisuals.Painted, comp.Enabled);
+        }
+
+        private ComponentData? SerializeLabelComponent(LabelComponent comp)
+        {
+            if (string.IsNullOrEmpty(comp.CurrentLabel))
+                return null;
+            return new ComponentData
+            {
+                Type = "LabelComponent",
+                Properties = new Dictionary<string, object> { ["CurrentLabel"] = comp.CurrentLabel },
+            };
+        }
+
+        private void RestoreLabelComponent(EntityUid uid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("CurrentLabel", out var labelObj))
+                return;
+            var text = labelObj?.ToString();
+            if (!string.IsNullOrEmpty(text))
+                _labelSystem.Label(uid, text);
+        }
+
+        private ComponentData? SerializePaperComponent(PaperComponent comp)
+        {
+            if (string.IsNullOrEmpty(comp.Content) && comp.StampedBy.Count == 0 && comp.StampState == null && !comp.EditingDisabled)
+                return null;
+            var props = new Dictionary<string, object>();
+            if (!string.IsNullOrEmpty(comp.Content))
+                props["Content"] = comp.Content;
+            if (comp.StampState != null)
+                props["StampState"] = comp.StampState;
+            if (comp.EditingDisabled)
+                props["EditingDisabled"] = (object)true;
+            if (comp.StampedBy.Count > 0)
+            {
+                props["Stamps"] = comp.StampedBy
+                    .Select(s => (object)new Dictionary<string, object>
+                    {
+                        ["Name"] = s.StampedName,
+                        ["Color"] = s.StampedColor.ToHex(),
+                        ["Type"] = s.Type.ToString(),
+                        ["Reapply"] = (object)s.Reapply,
+                    })
+                    .ToList();
+            }
+            return props.Count == 0 ? null : new ComponentData { Type = "PaperComponent", Properties = props };
+        }
+
+        private void RestorePaperComponent(EntityUid uid, ComponentData componentData)
+        {
+            var comp = EnsureComp<PaperComponent>(uid);
+            if (componentData.Properties.TryGetValue("Content", out var contentObj))
+                comp.Content = contentObj?.ToString() ?? string.Empty;
+            if (componentData.Properties.TryGetValue("StampState", out var stateObj))
+                comp.StampState = stateObj?.ToString();
+            if (componentData.Properties.TryGetValue("EditingDisabled", out var disabledObj)
+                && bool.TryParse(disabledObj?.ToString(), out var disabled))
+                comp.EditingDisabled = disabled;
+            if (componentData.Properties.TryGetValue("Stamps", out var stampsObj) && stampsObj is List<object> stampsList)
+            {
+                comp.StampedBy = new List<StampDisplayInfo>();
+                foreach (var item in stampsList)
+                {
+                    var dict = CoerceToDictStringObj(item);
+                    if (dict == null)
+                        continue;
+                    var info = new StampDisplayInfo
+                    {
+                        StampedName = dict.GetValueOrDefault("Name")?.ToString() ?? string.Empty,
+                        StampedColor = dict.TryGetValue("Color", out var cObj) && cObj is string ch
+                            ? Color.FromHex(ch)
+                            : Color.Red,
+                        Type = Enum.TryParse<StampType>(dict.GetValueOrDefault("Type")?.ToString(), out var st)
+                            ? st
+                            : StampType.RubberStamp,
+                        Reapply = bool.TryParse(dict.GetValueOrDefault("Reapply")?.ToString(), out var rp) && rp,
+                    };
+                    comp.StampedBy.Add(info);
+                }
+            }
+            Dirty(uid, comp);
+        }
+
+        private ComponentData? SerializeRandomSpriteComponent(RandomSpriteComponent comp)
+        {
+            if (comp.Selected.Count == 0)
+                return null;
+            var selected = comp.Selected.ToDictionary(
+                kv => kv.Key,
+                kv => (object)new Dictionary<string, object?>
+                {
+                    ["State"] = kv.Value.State,
+                    ["Color"] = kv.Value.Color.HasValue ? (object?)kv.Value.Color.Value.ToHex() : null,
+                });
+            return new ComponentData
+            {
+                Type = "RandomSpriteComponent",
+                Properties = new Dictionary<string, object> { ["Selected"] = selected },
+            };
+        }
+
+        private void RestoreRandomSpriteComponent(EntityUid uid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("Selected", out var selectedObj))
+                return;
+            var selectedDict = CoerceToDictStringObj(selectedObj);
+            if (selectedDict == null)
+                return;
+            var comp = EnsureComp<RandomSpriteComponent>(uid);
+            comp.Selected.Clear();
+            foreach (var (layer, entryObj) in selectedDict)
+            {
+                var entry = CoerceToDictStringObj(entryObj);
+                if (entry == null)
+                    continue;
+                var state = entry.GetValueOrDefault("State")?.ToString() ?? string.Empty;
+                Color? color = null;
+                if (entry.TryGetValue("Color", out var colorObj) && colorObj is string colorHex && !string.IsNullOrEmpty(colorHex))
+                    color = Color.FromHex(colorHex);
+                comp.Selected[layer] = (state, color);
+            }
+            Dirty(uid, comp);
+        }
+
+        private ComponentData? SerializeStorageLocationsComponent(EntityUid entityUid, StorageComponent storage)
+        {
+            if (storage.StoredItems.Count == 0)
+                return null;
+            var locations = new Dictionary<string, object>();
+            foreach (var (item, loc) in storage.StoredItems)
+            {
+                locations[item.ToString()] = new Dictionary<string, object>
+                {
+                    ["X"] = loc.Position.X,
+                    ["Y"] = loc.Position.Y,
+                    ["Rotation"] = (int)loc.Direction,
+                };
+            }
+            return new ComponentData
+            {
+                Type = "StorageComponent",
+                Properties = new Dictionary<string, object> { ["Locations"] = locations },
+            };
+        }
+
+        private void RestoreStorageLocations(List<EntityData> entityDataList, Dictionary<string, EntityUid> idMap)
+        {
+            foreach (var entityData in entityDataList)
+            {
+                if (!idMap.TryGetValue(entityData.EntityId, out var storageUid))
+                    continue;
+
+                var storageComponentData = entityData.Components
+                    .FirstOrDefault(c => c.Type == "StorageComponent" && c.Properties.ContainsKey("Locations"));
+                if (storageComponentData == null)
+                    continue;
+
+                if (!_entityManager.TryGetComponent<StorageComponent>(storageUid, out var storageComp))
+                    continue;
+
+                var locationsRaw = CoerceToDictStringObj(storageComponentData.Properties["Locations"]);
+                if (locationsRaw == null)
+                    continue;
+
+                var anySet = false;
+                foreach (var (oldItemIdStr, locObj) in locationsRaw)
+                {
+                    if (!idMap.TryGetValue(oldItemIdStr, out var newItemUid))
+                        continue;
+
+                    // Only restore position for items actually inside this storage.
+                    if (!storageComp.Container.ContainedEntities.Contains(newItemUid))
+                        continue;
+
+                    var locDict = CoerceToDictStringObj(locObj);
+                    if (locDict == null)
+                        continue;
+
+                    if (!int.TryParse(locDict.GetValueOrDefault("X")?.ToString(), out var x))
+                        continue;
+                    if (!int.TryParse(locDict.GetValueOrDefault("Y")?.ToString(), out var y))
+                        continue;
+                    if (!int.TryParse(locDict.GetValueOrDefault("Rotation")?.ToString(), out var rot))
+                        rot = 0;
+
+                    // Assign directly to StoredItems, bypassing ItemFitsInGridLocation.
+                    // We are restoring a layout that was valid at save time, so the positions
+                    // are known-good. Using TrySetItemStorageLocation would fail for items whose
+                    // saved position is currently occupied by another item that hasn't been moved
+                    // yet (ordering issue), corrupting the layout.
+                    storageComp.StoredItems[newItemUid] = new ItemStorageLocation(Angle.Zero, new Vector2i(x, y))
+                    {
+                        Direction = (Direction)rot
+                    };
+                    anySet = true;
+                }
+
+                if (anySet)
+                {
+                    _storageSystem.UpdateUI((storageUid, storageComp));
+                    Dirty(storageUid, storageComp);
+                }
+            }
+        }
 
         private static readonly Dictionary<Type, bool> ComponentSkipCache = new();
 
@@ -2072,8 +2529,8 @@ namespace Content.Server.Shuttles.Save
             else if (typeName.Contains("Physics"))
                 shouldSkip = true;
 
-            // Skip appearance/visual components (usually regenerated)
-            else if (typeName.Contains("Appearance") || typeName.Contains("Sprite"))
+            // Skip client-side sprite components (not present server-side)
+            else if (typeName.Contains("Sprite"))
                 shouldSkip = true;
 
             // Skip network/client-side components
@@ -2284,6 +2741,23 @@ namespace Content.Server.Shuttles.Save
             }
         }
 
+        /// <summary>
+        /// YamlDotNet deserializes nested YAML mappings into Dictionary&lt;object, object&gt;
+        /// when the declared target type is Dictionary&lt;string, object&gt;.
+        /// This helper normalises both forms so callers don't need to branch on the runtime type.
+        /// </summary>
+        private static Dictionary<string, object>? CoerceToDictStringObj(object? value)
+        {
+            return value switch
+            {
+                Dictionary<string, object> d => d,
+                Dictionary<object, object> od => od.ToDictionary(
+                    kv => kv.Key?.ToString() ?? string.Empty,
+                    kv => kv.Value),
+                _ => null
+            };
+        }
+
         private void RestoreSolutionComponent(EntityUid entityUid, ComponentData componentData)
         {
             try
@@ -2297,7 +2771,8 @@ namespace Content.Server.Shuttles.Save
                 var restoredSolutions = 0;
                 foreach (var (solutionName, solutionDataObj) in componentData.Properties)
                 {
-                    if (solutionDataObj is not Dictionary<string, object> solutionInfo)
+                    var solutionInfo = CoerceToDictStringObj(solutionDataObj);
+                    if (solutionInfo == null)
                         continue;
 
                     try
@@ -2341,15 +2816,18 @@ namespace Content.Server.Shuttles.Save
                         }
 
                         // Restore reagents
-                        if (solutionInfo.TryGetValue("Reagents", out var reagentsObj) &&
-                            reagentsObj is Dictionary<string, object> reagents)
+                        if (solutionInfo.TryGetValue("Reagents", out var reagentsObj))
                         {
-                            foreach (var (reagentId, quantityObj) in reagents)
+                            var reagents = CoerceToDictStringObj(reagentsObj);
+                            if (reagents != null)
                             {
-                                if (TryConvertToDouble(quantityObj, out var quantity) && quantity > 0)
+                                foreach (var (reagentId, quantityObj) in reagents)
                                 {
-                                    // Add the reagent back to the solution
-                                    solution?.AddReagent(reagentId, (float)quantity);
+                                    if (TryConvertToDouble(quantityObj, out var quantity) && quantity > 0)
+                                    {
+                                        // Add the reagent back to the solution
+                                        solution?.AddReagent(reagentId, (float)quantity);
+                                    }
                                 }
                             }
                         }
@@ -2357,9 +2835,9 @@ namespace Content.Server.Shuttles.Save
                         _solutionContainerSystem.UpdateChemicals(restoredSolutionEntity, false);
 
                         restoredSolutions++;
-                        var reagentCount = solutionInfo.ContainsKey("Reagents") &&
-                                          solutionInfo["Reagents"] is Dictionary<string, object> reagentDict ?
-                                          reagentDict.Count : 0;
+                        var reagentCount = solutionInfo.TryGetValue("Reagents", out var reagentRaw)
+                                          ? (CoerceToDictStringObj(reagentRaw)?.Count ?? 0)
+                                          : 0;
                         _sawmill.Debug($"Restored solution '{solutionName}' with {reagentCount} reagents");
                     }
                     catch (Exception ex)
@@ -2452,7 +2930,7 @@ namespace Content.Server.Shuttles.Save
             return _entityManager.HasComponent<ContainerManagerComponent>(entityUid);
         }
 
-        private EntityData? SerializeEntity(EntityUid uid, TransformComponent transform, string prototype, EntityUid gridId)
+        private EntityData? SerializeEntity(EntityUid uid, TransformComponent transform, string prototype, EntityUid gridId, bool roomMode = false)
         {
             try
             {
@@ -2480,7 +2958,7 @@ namespace Content.Server.Shuttles.Save
                 var isContainer = HasContainers(uid);
 
                 // Serialize component states
-                var components = SerializeEntityComponents(uid);
+                var components = SerializeEntityComponents(uid, roomMode);
 
                 // Use entity's current position and rotation (grid is already normalized to 0°)
                 var position = transform.LocalPosition;
@@ -2518,10 +2996,10 @@ namespace Content.Server.Shuttles.Save
             }
         }
 
-        private void SerializeContainedEntities(EntityUid gridId, GridData gridData, HashSet<EntityUid> alreadySerialized)
+        private void SerializeContainedEntities(EntityUid gridId, GridData gridData, HashSet<EntityUid> alreadySerialized, bool includeVendors = false, bool roomMode = false)
         {
             var verbose = _configManager.GetCVar(Content.Shared.CCVar.CCVars.ShipyardSaveVerbose);
-            var excludeVending = _configManager.GetCVar(Content.Shared.HL.CCVar.HLCCVars.ExcludeVendingInShipSave);
+            var excludeVending = !includeVendors && _configManager.GetCVar(Content.Shared.HL.CCVar.HLCCVars.ExcludeVendingInShipSave);
             // Find all entities that might be contained within grid entities but not directly on the grid
             var containersToCheck = new Queue<EntityUid>();
 
@@ -2576,7 +3054,7 @@ namespace Content.Server.Shuttles.Save
                                 continue; // Skip contained vending machines
                             }
 
-                            var entityData = SerializeEntity(containedEntity, transform, proto, gridId);
+                            var entityData = SerializeEntity(containedEntity, transform, proto, gridId, roomMode);
                             if (entityData != null)
                             {
                                 gridData.Entities.Add(entityData);

--- a/Content.Server/Shuttles/ShipSerializationSystem.cs
+++ b/Content.Server/Shuttles/ShipSerializationSystem.cs
@@ -65,6 +65,7 @@ using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Sprite;
 using Content.Shared.Tag;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Clothing.EntitySystems;
 using Content.Server.Clothing.Systems;
 
 namespace Content.Server.Shuttles.Save
@@ -94,6 +95,7 @@ namespace Content.Server.Shuttles.Save
         [Dependency] private readonly LabelSystem _labelSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly ChameleonClothingSystem _chameleonSystem = default!;
+        [Dependency] private readonly ToggleableClothingSystem _toggleableClothingSystem = default!;
         // Note: For EntityDeserializer we use IoCManager.Instance directly to avoid extra injected fields.
 
         private ISawmill _sawmill = default!;
@@ -3178,14 +3180,14 @@ namespace Content.Server.Shuttles.Save
                         if (containerId == Content.Server.Light.EntitySystems.PoweredLightSystem.LightBulbContainer)
                             continue;
                         // Clear default spawned items - we'll restore saved contents later.
-                        // Null out AttachedClothingComponent.AttachedUid first so that deleting
-                        // an auto-spawned helmet doesn't trigger OnRemoveAttached, which would
+                        // Disconnect AttachedClothingComponent first so that deleting an
+                        // auto-spawned helmet doesn't trigger OnRemoveAttached, which would
                         // strip ToggleableClothingComponent off the parent suit.
                         var defaultItems = container.ContainedEntities.ToList();
                         foreach (var defaultItem in defaultItems)
                         {
                             if (_entityManager.TryGetComponent<AttachedClothingComponent>(defaultItem, out var attached))
-                                attached.AttachedUid = EntityUid.Invalid;
+                                _toggleableClothingSystem.DisconnectAttachedClothing(attached);
                             _containerSystem.Remove(defaultItem, container);
                             _entityManager.DeleteEntity(defaultItem);
                         }

--- a/Content.Server/Shuttles/ShipSerializationSystem.cs
+++ b/Content.Server/Shuttles/ShipSerializationSystem.cs
@@ -65,6 +65,7 @@ using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Sprite;
 using Content.Shared.Tag;
 using Content.Shared.Clothing.Components;
+using Content.Server.Clothing.Systems;
 
 namespace Content.Server.Shuttles.Save
 {
@@ -92,6 +93,7 @@ namespace Content.Server.Shuttles.Save
         [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
         [Dependency] private readonly LabelSystem _labelSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly ChameleonClothingSystem _chameleonSystem = default!;
         // Note: For EntityDeserializer we use IoCManager.Instance directly to avoid extra injected fields.
 
         private ISawmill _sawmill = default!;
@@ -2163,6 +2165,11 @@ namespace Content.Server.Shuttles.Save
                 var d = SerializeRandomSpriteComponent(randomSprite);
                 if (d != null) entityData.Components.Add(d);
             }
+            if (_entityManager.TryGetComponent<ChameleonClothingComponent>(uid, out var chameleon))
+            {
+                var d = SerializeChameleonClothingComponent(chameleon);
+                if (d != null) entityData.Components.Add(d);
+            }
         }
 
         private void RestoreRoomComponents(EntityUid uid, EntityData entityData)
@@ -2183,6 +2190,8 @@ namespace Content.Server.Shuttles.Save
                     RestorePaperComponent(uid, componentData);
                 else if (componentData.Type == "RandomSpriteComponent" && componentData.Properties.Any())
                     RestoreRandomSpriteComponent(uid, componentData);
+                else if (componentData.Type == "ChameleonClothingComponent" && componentData.Properties.Any())
+                    RestoreChameleonClothingComponent(uid, componentData);
                 // StorageComponent locations handled in RestoreStorageLocations post-pass
             }
         }
@@ -2424,6 +2433,26 @@ namespace Content.Server.Shuttles.Save
                 comp.Selected[layer] = (state, color);
             }
             Dirty(uid, comp);
+        }
+
+        private ComponentData? SerializeChameleonClothingComponent(ChameleonClothingComponent comp)
+        {
+            if (string.IsNullOrEmpty(comp.Default))
+                return null;
+            return new ComponentData
+            {
+                Type = "ChameleonClothingComponent",
+                Properties = new Dictionary<string, object> { ["Default"] = comp.Default }
+            };
+        }
+
+        private void RestoreChameleonClothingComponent(EntityUid uid, ComponentData componentData)
+        {
+            if (!componentData.Properties.TryGetValue("Default", out var protoObj))
+                return;
+            var protoId = protoObj?.ToString();
+            if (!string.IsNullOrEmpty(protoId))
+                _chameleonSystem.SetSelectedPrototype(uid, protoId, forceUpdate: true);
         }
 
         private ComponentData? SerializeStorageLocationsComponent(EntityUid entityUid, StorageComponent storage)

--- a/Content.Server/Shuttles/ShipSerializationSystem.cs
+++ b/Content.Server/Shuttles/ShipSerializationSystem.cs
@@ -64,6 +64,7 @@ using Content.Shared.Labels.Components;
 using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Sprite;
 using Content.Shared.Tag;
+using Content.Shared.Clothing.Components;
 
 namespace Content.Server.Shuttles.Save
 {
@@ -3147,10 +3148,15 @@ namespace Content.Server.Shuttles.Save
                         // Do not clear powered light bulb containers; ships would spawn dark.
                         if (containerId == Content.Server.Light.EntitySystems.PoweredLightSystem.LightBulbContainer)
                             continue;
-                        // Clear default spawned items - we'll restore saved contents later
+                        // Clear default spawned items - we'll restore saved contents later.
+                        // Null out AttachedClothingComponent.AttachedUid first so that deleting
+                        // an auto-spawned helmet doesn't trigger OnRemoveAttached, which would
+                        // strip ToggleableClothingComponent off the parent suit.
                         var defaultItems = container.ContainedEntities.ToList();
                         foreach (var defaultItem in defaultItems)
                         {
+                            if (_entityManager.TryGetComponent<AttachedClothingComponent>(defaultItem, out var attached))
+                                attached.AttachedUid = EntityUid.Invalid;
                             _containerSystem.Remove(defaultItem, container);
                             _entityManager.DeleteEntity(defaultItem);
                         }

--- a/Content.Server/_HL/Rooms/RoomGridSpawnerSystem.cs
+++ b/Content.Server/_HL/Rooms/RoomGridSpawnerSystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.Popups;
 using Content.Server.Shuttles.Save;
 using Content.Shared._HL.Rooms;
+using Content.Shared.SprayPainter.Components;
+using Content.Shared.SprayPainter.Prototypes;
 using Content.Shared.Interaction;
 using Content.Server.Mind;
 using Content.Shared.Mind;
@@ -254,13 +256,31 @@ public sealed class RoomGridSpawnerSystem : EntitySystem
         ResetRoom(userId, session);
     }
 
+    private void StampSprayPaintedInBounds(EntityUid gridId, Box2 bounds)
+    {
+        var query = EntityQueryEnumerator<SprayPaintedComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var painted, out var xform))
+        {
+            if (xform.GridUid != gridId)
+                continue;
+            if (!bounds.Contains(xform.LocalPosition))
+                continue;
+            if (_appearance.TryGetData(uid, PaintableVisuals.Prototype, out string styleProto))
+            {
+                painted.PaintedPrototype = styleProto;
+                Dirty(uid, painted);
+            }
+        }
+    }
+
     private bool TrySaveRoom(NetUserId userId, ActiveRoomSession session)
     {
         if (!_gridQuery.TryComp(session.GridUid, out var gridComp))
             return false;
 
         var excluded = new HashSet<EntityUid> { session.ConsoleUid, session.MarkerUid };
-        var shipData = _shipSerialization.SerializeShipArea(session.GridUid, userId, $"Room_{session.CharacterKey}", session.Bounds, excluded);
+        StampSprayPaintedInBounds(session.GridUid, session.Bounds);
+        var shipData = _shipSerialization.SerializeShipArea(session.GridUid, userId, $"Room_{session.CharacterKey}", session.Bounds, excluded, includeVendors: true);
         NormalizeRoomDataToAnchor(shipData, session.AnchorTile, session.AnchorPosition, session.AnchorRotation);
         var yaml = _shipSerialization.SerializeShipGridDataToYaml(shipData);
 

--- a/Content.Server/_HL/Save/RoomSaveRules.cs
+++ b/Content.Server/_HL/Save/RoomSaveRules.cs
@@ -1,0 +1,64 @@
+namespace Content.Server._HL.Save;
+
+/// <summary>
+/// Shared filtering rules for the room save format (ShipGridData / custom serializer path).
+/// Ship saves use a separate YAML-level sanitizer (<see cref="Content.Server._HL.Shipyard.ShipSaveYamlSanitizer"/>);
+/// room saves apply equivalent rules at the ECS level inside SerializeShipArea.
+/// </summary>
+public static class RoomSaveRules
+{
+    /// <summary>
+    /// Entity prototype IDs that must never appear in room saves.
+    /// Mirrors the spirit of ShipSaveYamlSanitizer.FilteredPrototypes for the room context.
+    /// </summary>
+    public static readonly IReadOnlySet<string> FilteredPrototypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "ContainmentField",
+        "PortalBlue",
+        "PortalRed",
+        "ShipShield",
+    };
+
+    /// <summary>
+    /// Component type names (without namespace) that, when present on an entity, cause that
+    /// entity to be excluded from the room save entirely.
+    /// Mirrors ShipSaveYamlSanitizer.FilteredEntityByComponentTypes for the room context.
+    /// </summary>
+    public static readonly IReadOnlySet<string> EntityExclusionComponentNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "GhostComponent",
+        "GhostRoleComponent",
+        "HumanoidAppearanceComponent",
+        "MindContainerComponent",
+        "MobStateComponent",
+    };
+
+    /// <summary>
+    /// Component type names that should be stripped from entity data during a room save.
+    /// Mirrors ShipSaveYamlSanitizer.FilteredTypes for the room context.
+    /// These are resolved at the ECS level via IsProblematicComponent in ShipSerializationSystem.
+    /// </summary>
+    public static readonly IReadOnlySet<string> FilteredComponentNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "JointComponent",
+        "StationMemberComponent",
+        "NavMapComponent",
+        "ShuttleDeedComponent",
+        "IFFComponent",
+        "LinkedLifecycleGridParentComponent",
+        "DeviceNetworkComponent",
+        "UserInterfaceComponent",
+        "DockingComponent",
+        "ActionGrantComponent",
+        "MindComponent",
+        "MindContainerComponent",
+        "ForensicsComponent",
+        "ContainmentFieldGeneratorComponent",
+        "ActionsComponent",
+        "ProjectileComponent",
+        "ItemToggleActiveSoundComponent",
+        "BlockingComponent",
+        "TurnstileComponent",
+        "SubdermalImplantComponent",
+    };
+}

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -442,6 +442,16 @@ public sealed class ToggleableClothingSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    /// Clears the attachment link on a helmet before it is deleted during container restoration,
+    /// preventing <see cref="OnRemoveAttached"/> from stripping <see cref="ToggleableClothingComponent"/>
+    /// off the parent suit. Only call this immediately before deletion.
+    /// </summary>
+    public void DisconnectAttachedClothing(AttachedClothingComponent comp)
+    {
+        comp.AttachedUid = EntityUid.Invalid;
+    }
+
     private void OnInit(EntityUid uid, ToggleableClothingComponent component, ComponentInit args)
     {
         // Only create container for legacy clothing mode, not for marking mode

--- a/Content.Tests/Server/_HL/Rooms/RoomSaveTest.cs
+++ b/Content.Tests/Server/_HL/Rooms/RoomSaveTest.cs
@@ -1,0 +1,491 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Content.Server._HL.Save;
+using NUnit.Framework;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+#nullable enable
+
+namespace Content.Tests.Server._HL.Rooms;
+
+/// <summary>
+/// Unit tests for room-save serialization correctness.
+/// These cover the bugs fixed in the room save path:
+///   1. FixedPoint2 values survive YamlDotNet round-trip as double scalars.
+///   2. Nested Dictionary&lt;object,object&gt; from YamlDotNet is coerced correctly.
+///   3. Room save filter rule constants are well-formed.
+/// All tests are pure (no ECS required).
+/// </summary>
+[TestFixture, Parallelizable(ParallelScope.All)]
+public sealed class RoomSaveTest
+{
+    // ---------------------------------------------------------------------------
+    // Helpers: minimal YamlDotNet round-trip (mirrors ShipSerializationSystem)
+    // ---------------------------------------------------------------------------
+
+    private static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .Build();
+
+    private static T? RoundTrip<T>(T value)
+    {
+        var yaml = Serializer.Serialize(value);
+        return Deserializer.Deserialize<T>(yaml);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Bug fix 1: FixedPoint2-as-double survives round-trip
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void DoubleValueSurvivesYamlRoundTrip()
+    {
+        var original = new Dictionary<string, object>
+        {
+            ["water"] = 5.5,
+            ["ethanol"] = 12.0,
+        };
+
+        var yaml = Serializer.Serialize(original);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!.ContainsKey("water"), Is.True, "water key should survive round-trip");
+
+        var waterObj = restored["water"];
+        // YamlDotNet deserializes scalars as strings when target is object
+        var ok = waterObj switch
+        {
+            double d => Math.Abs(d - 5.5) < 0.001,
+            string s => double.TryParse(s, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+                && Math.Abs(parsed - 5.5) < 0.001,
+            _ => false
+        };
+        Assert.That(ok, Is.True,
+            $"Expected ~5.5 after round-trip, got '{waterObj}' ({waterObj?.GetType().Name})");
+    }
+
+    [Test]
+    public void EmptyStructAsObjectDoesNotSurviveRoundTripAsUsefulValue()
+    {
+        // This test documents the OLD bug: a struct with no public properties
+        // (like FixedPoint2 when boxed as object) serializes as {} and comes
+        // back as Dictionary<object,object>, which TryConvertToDouble cannot handle.
+        var dummy = new EmptyStruct();
+        var original = new Dictionary<string, object> { ["qty"] = dummy };
+
+        var yaml = Serializer.Serialize(original);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        var qty = restored!["qty"];
+        // Cannot be used as a numeric value — it comes back as Dictionary<object,object>
+        var isUsable = qty is double or float or int or long or string;
+        Assert.That(isUsable, Is.False,
+            "A struct with no public fields round-trips to a dict, not a scalar — " +
+            "this is why FixedPoint2 must be cast to double before storage.");
+    }
+
+    private struct EmptyStruct { }
+
+    // ---------------------------------------------------------------------------
+    // Bug fix 2: CoerceToDictStringObj handles both dict kinds
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void CoerceToDictStringObj_AcceptsDictStringObj()
+    {
+        var input = new Dictionary<string, object> { ["a"] = "hello" };
+        var result = CoerceToDictStringObj(input);
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!["a"], Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void CoerceToDictStringObj_AcceptsDictObjObj()
+    {
+        var input = new Dictionary<object, object> { ["b"] = 42 };
+        var result = CoerceToDictStringObj(input);
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ContainsKey("b"), Is.True, "key 'b' should be preserved after coercion");
+        Assert.That(result["b"], Is.EqualTo(42));
+    }
+
+    [Test]
+    public void CoerceToDictStringObj_ReturnsNullForUnrelatedTypes()
+    {
+        Assert.That(CoerceToDictStringObj(null), Is.Null);
+        Assert.That(CoerceToDictStringObj(42), Is.Null);
+        Assert.That(CoerceToDictStringObj("hello"), Is.Null);
+    }
+
+    [Test]
+    public void CoerceToDictStringObj_HandlesNestedDictFromYaml()
+    {
+        // Simulate the nested solution data that YamlDotNet produces:
+        // Properties["default"] → Dictionary<object,object> { "Reagents" → Dictionary<object,object> { "water" → "5.5" } }
+        var innerReagents = new Dictionary<object, object> { ["water"] = "5.5" };
+        var innerSolution = new Dictionary<object, object>
+        {
+            ["MaxVolume"] = "100.0",
+            ["Temperature"] = "293.15",
+            ["Reagents"] = innerReagents,
+        };
+
+        var solutionInfo = CoerceToDictStringObj(innerSolution);
+        Assert.That(solutionInfo, Is.Not.Null);
+
+        var reagentsRaw = solutionInfo!.TryGetValue("Reagents", out var r) ? r : null;
+        var reagents = CoerceToDictStringObj(reagentsRaw);
+        Assert.That(reagents, Is.Not.Null, "Reagents inner dict should also be coercible");
+        Assert.That(reagents!.ContainsKey("water"), Is.True);
+        Assert.That(reagents["water"]?.ToString(), Is.EqualTo("5.5"));
+    }
+
+    // Local copy of the helper (duplicated from ShipSerializationSystem to keep tests pure)
+    private static Dictionary<string, object>? CoerceToDictStringObj(object? value)
+    {
+        return value switch
+        {
+            Dictionary<string, object> d => d,
+            Dictionary<object, object> od => od.ToDictionary(
+                kv => kv.Key?.ToString() ?? string.Empty,
+                kv => kv.Value),
+            _ => null
+        };
+    }
+
+    // ---------------------------------------------------------------------------
+    // Bug fix 3: Solution data with doubles round-trips correctly end-to-end
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void SolutionDataWithDoublesRoundTripsCorrectly()
+    {
+        // Simulate what SerializeSolutionComponent now produces (after fix)
+        var solutionData = new Dictionary<string, object>
+        {
+            ["default"] = new Dictionary<string, object>
+            {
+                ["Volume"] = 30.0,
+                ["MaxVolume"] = 100.0,
+                ["Temperature"] = 293.15f,
+                ["Reagents"] = new Dictionary<string, object>
+                {
+                    ["Water"] = 20.0,
+                    ["Ethanol"] = 10.0,
+                }
+            }
+        };
+
+        // Round-trip through YamlDotNet (as ComponentData.Properties would be)
+        var yaml = Serializer.Serialize(solutionData);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+
+        // RestoreSolutionComponent uses CoerceToDictStringObj for the outer value
+        var solutionInfo = CoerceToDictStringObj(restored!["default"]);
+        Assert.That(solutionInfo, Is.Not.Null, "Outer solution info should be coercible");
+
+        // MaxVolume should be parseable as double
+        Assert.That(solutionInfo!.ContainsKey("MaxVolume"), Is.True);
+        var maxVolObj = solutionInfo["MaxVolume"];
+        var maxVolOk = maxVolObj switch
+        {
+            double d => d > 0,
+            string s => double.TryParse(s, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var v) && v > 0,
+            _ => false
+        };
+        Assert.That(maxVolOk, Is.True, $"MaxVolume '{maxVolObj}' should be parseable as a positive number");
+
+        // Reagents should be present and coercible
+        var reagentsRaw = solutionInfo.TryGetValue("Reagents", out var rr) ? rr : null;
+        var reagents = CoerceToDictStringObj(reagentsRaw);
+        Assert.That(reagents, Is.Not.Null, "Reagents should be coercible");
+        Assert.That(reagents!.ContainsKey("Water"), Is.True, "Water reagent should survive round-trip");
+
+        var waterQty = reagents["Water"];
+        var waterOk = waterQty switch
+        {
+            double d => Math.Abs(d - 20.0) < 0.01,
+            string s => double.TryParse(s, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var v) && Math.Abs(v - 20.0) < 0.01,
+            _ => false
+        };
+        Assert.That(waterOk, Is.True, $"Water qty '{waterQty}' should be ~20.0");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Filter rule sanity
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void RoomSaveRules_FilteredPrototypesIsNonEmpty()
+    {
+        Assert.That(RoomSaveRules.FilteredPrototypes, Is.Not.Empty,
+            "FilteredPrototypes should contain at least the ContainmentField prototype");
+        Assert.That(RoomSaveRules.FilteredPrototypes, Contains.Item("ContainmentField"),
+            "ContainmentField should be filtered from room saves");
+    }
+
+    [Test]
+    public void RoomSaveRules_EntityExclusionContainsExpectedComponents()
+    {
+        Assert.That(RoomSaveRules.EntityExclusionComponentNames, Contains.Item("GhostComponent"),
+            "Ghosts must be excluded from room saves");
+        Assert.That(RoomSaveRules.EntityExclusionComponentNames, Contains.Item("MobStateComponent"),
+            "Mobs must be excluded from room saves");
+        Assert.That(RoomSaveRules.EntityExclusionComponentNames, Contains.Item("HumanoidAppearanceComponent"),
+            "Player humanoids must be excluded from room saves");
+    }
+
+    [Test]
+    public void RoomSaveRules_FilteredComponentNamesDoesNotContainVendingMachine()
+    {
+        // Vendors SHOULD be saved in rooms (they're placed there intentionally).
+        Assert.That(RoomSaveRules.FilteredComponentNames, Does.Not.Contain("VendingMachineComponent"),
+            "VendingMachineComponent must NOT be in the room component filter — vendors must be saved");
+    }
+
+    [Test]
+    public void RoomSaveRules_FilteredComponentNamesContainsRuntimeOnlyComponents()
+    {
+        Assert.That(RoomSaveRules.FilteredComponentNames, Contains.Item("ActionsComponent"),
+            "ActionsComponent is runtime-only and must be filtered");
+        Assert.That(RoomSaveRules.FilteredComponentNames, Contains.Item("DockingComponent"),
+            "DockingComponent is ship-specific runtime state and must be filtered");
+        Assert.That(RoomSaveRules.FilteredComponentNames, Contains.Item("MindContainerComponent"),
+            "MindContainerComponent must be filtered to avoid serializing player state");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Component round-trip helpers (mirrors ShipSerializationSystem logic)
+    // ---------------------------------------------------------------------------
+
+    private static Dictionary<string, object> MakePaintedProps(string colorHex, bool enabled, string shaderName = "Greyscale")
+        => new() { ["Color"] = colorHex, ["Enabled"] = enabled, ["ShaderName"] = shaderName };
+
+    private static Dictionary<string, object> MakeLabelProps(string label)
+        => new() { ["CurrentLabel"] = label };
+
+    private static Dictionary<string, object> MakePaperProps(string? content = null, string? stampState = null, bool editingDisabled = false, List<Dictionary<string, object>>? stamps = null)
+    {
+        var props = new Dictionary<string, object>();
+        if (content != null) props["Content"] = content;
+        if (stampState != null) props["StampState"] = stampState;
+        if (editingDisabled) props["EditingDisabled"] = (object)true;
+        if (stamps != null && stamps.Count > 0) props["Stamps"] = stamps.Cast<object>().ToList();
+        return props;
+    }
+
+    private static Dictionary<string, object> MakeRandomSpriteProps(Dictionary<string, (string State, string? ColorHex)> selected)
+    {
+        var inner = selected.ToDictionary(
+            kv => kv.Key,
+            kv => (object)new Dictionary<string, object?>
+            {
+                ["State"] = kv.Value.State,
+                ["Color"] = (object?)kv.Value.ColorHex,
+            });
+        return new Dictionary<string, object> { ["Selected"] = inner };
+    }
+
+    // ---------------------------------------------------------------------------
+    // PaintedComponent round-trip
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void PaintedComponent_ColorAndEnabledSurviveRoundTrip()
+    {
+        var props = MakePaintedProps("#C063F5FF", enabled: true);
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!["Color"]?.ToString(), Is.EqualTo("#C063F5FF"), "Color hex must survive round-trip");
+        var ok = restored["Enabled"] switch
+        {
+            bool b => b,
+            string s => bool.Parse(s),
+            _ => false,
+        };
+        Assert.That(ok, Is.True, "Enabled flag must be true after round-trip");
+    }
+
+    [Test]
+    public void PaintedComponent_DisabledIsNotSerialized()
+    {
+        // Disabled (unpainted) entities produce null from SerializePaintedComponent —
+        // verified here by checking the Enabled=false guard.
+        var props = MakePaintedProps("#C063F5FF", enabled: false);
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+        Assert.That(restored, Is.Not.Null);
+        var enabled = restored!["Enabled"] switch
+        {
+            bool b => b,
+            string s => bool.Parse(s),
+            _ => true,
+        };
+        Assert.That(enabled, Is.False, "A disabled PaintedComponent should round-trip as false");
+    }
+
+    // ---------------------------------------------------------------------------
+    // LabelComponent round-trip
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void LabelComponent_CurrentLabelSurvivesRoundTrip()
+    {
+        var props = MakeLabelProps("Ammo Storage");
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!["CurrentLabel"]?.ToString(), Is.EqualTo("Ammo Storage"));
+    }
+
+    [Test]
+    public void LabelComponent_EmptyLabelProducesNoEntry()
+    {
+        // Empty/null labels are skipped by SerializeLabelComponent (returns null).
+        // Simulate: if CurrentLabel is empty string, Properties dict has no "CurrentLabel" key.
+        var props = new Dictionary<string, object>();
+        Assert.That(props.ContainsKey("CurrentLabel"), Is.False,
+            "Empty label must not produce a CurrentLabel entry");
+    }
+
+    // ---------------------------------------------------------------------------
+    // PaperComponent round-trip
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void PaperComponent_ContentSurvivesRoundTrip()
+    {
+        var content = "Dear Captain,\n\nPlease approve my vacation request.\n\n- Ensign";
+        var props = MakePaperProps(content: content);
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!["Content"]?.ToString(), Is.EqualTo(content), "Paper content must survive round-trip");
+    }
+
+    [Test]
+    public void PaperComponent_StampsSurviveRoundTrip()
+    {
+        var stamps = new List<Dictionary<string, object>>
+        {
+            new()
+            {
+                ["Name"] = "stamp-component-stamped-name-hos",
+                ["Color"] = "#CC0000FF",
+                ["Type"] = "RubberStamp",
+                ["Reapply"] = (object)false,
+            },
+            new()
+            {
+                ["Name"] = "Marisol Alliman",
+                ["Color"] = "#333333FF",
+                ["Type"] = "Signature",
+                ["Reapply"] = (object)false,
+            },
+        };
+        var props = MakePaperProps(stampState: "paper_stamp-hos", stamps: stamps);
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!["StampState"]?.ToString(), Is.EqualTo("paper_stamp-hos"));
+
+        var stampsRaw = restored["Stamps"];
+        Assert.That(stampsRaw, Is.Not.Null, "Stamps list must be present");
+        Assert.That(stampsRaw is List<object>, Is.True, "Stamps must deserialize as List<object>");
+        var stampList = (List<object>)stampsRaw!;
+        Assert.That(stampList.Count, Is.EqualTo(2));
+
+        var first = CoerceToDictStringObj(stampList[0]);
+        Assert.That(first, Is.Not.Null);
+        Assert.That(first!["Color"]?.ToString(), Is.EqualTo("#CC0000FF"));
+        Assert.That(first["Type"]?.ToString(), Is.EqualTo("RubberStamp"));
+
+        var second = CoerceToDictStringObj(stampList[1]);
+        Assert.That(second, Is.Not.Null);
+        Assert.That(second!["Type"]?.ToString(), Is.EqualTo("Signature"));
+    }
+
+    [Test]
+    public void PaperComponent_EditingDisabledSurvivesRoundTrip()
+    {
+        var props = MakePaperProps(content: "Classified", editingDisabled: true);
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        var disabled = restored!["EditingDisabled"] switch
+        {
+            bool b => b,
+            string s => bool.Parse(s),
+            _ => false,
+        };
+        Assert.That(disabled, Is.True, "EditingDisabled must survive round-trip");
+    }
+
+    [Test]
+    public void PaperComponent_BlankPaperProducesNoEntry()
+    {
+        // Blank, unstamped, unprotected paper → no Properties → null ComponentData.
+        var props = MakePaperProps();
+        Assert.That(props.Count, Is.Zero, "Blank paper must produce empty Properties dict (no ComponentData)");
+    }
+
+    // ---------------------------------------------------------------------------
+    // RandomSpriteComponent round-trip
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void RandomSpriteComponent_SelectedStatesSurviveRoundTrip()
+    {
+        var props = MakeRandomSpriteProps(new Dictionary<string, (string State, string? ColorHex)>
+        {
+            ["enum.ArtifactsVisualLayers.Base"] = ("martianball3", null),
+            ["pouchFill1"] = ("fill-util1-3", "#FF8800FF"),
+        });
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+
+        var selectedRaw = CoerceToDictStringObj(restored!["Selected"]);
+        Assert.That(selectedRaw, Is.Not.Null, "Selected dict must be coercible");
+
+        var baseLayer = CoerceToDictStringObj(selectedRaw!["enum.ArtifactsVisualLayers.Base"]);
+        Assert.That(baseLayer, Is.Not.Null);
+        Assert.That(baseLayer!["State"]?.ToString(), Is.EqualTo("martianball3"));
+        Assert.That(baseLayer["Color"], Is.Null.Or.Empty, "Null color must round-trip as null or empty");
+
+        var pouchLayer = CoerceToDictStringObj(selectedRaw["pouchFill1"]);
+        Assert.That(pouchLayer, Is.Not.Null);
+        Assert.That(pouchLayer!["State"]?.ToString(), Is.EqualTo("fill-util1-3"));
+        Assert.That(pouchLayer["Color"]?.ToString(), Is.EqualTo("#FF8800FF"));
+    }
+
+    [Test]
+    public void RandomSpriteComponent_EmptySelectedProducesNoEntry()
+    {
+        // Selected.Count == 0 → SerializeRandomSpriteComponent returns null.
+        // Simulate: empty dict → Properties is empty → removed by RemoveAll filter.
+        var props = MakeRandomSpriteProps(new Dictionary<string, (string State, string? ColorHex)>());
+        Assert.That(props.TryGetValue("Selected", out var sel) && sel is Dictionary<string, object> d && d.Count == 0,
+            Is.True, "Empty Selected must produce an empty inner dict");
+    }
+}

--- a/Content.Tests/Server/_HL/Rooms/RoomSaveTest.cs
+++ b/Content.Tests/Server/_HL/Rooms/RoomSaveTest.cs
@@ -488,4 +488,77 @@ public sealed class RoomSaveTest
         Assert.That(props.TryGetValue("Selected", out var sel) && sel is Dictionary<string, object> d && d.Count == 0,
             Is.True, "Empty Selected must produce an empty inner dict");
     }
+
+    // ---------------------------------------------------------------------------
+    // ChameleonClothingComponent round-trip
+    // ---------------------------------------------------------------------------
+
+    private static Dictionary<string, object> MakeChameleonProps(string selectedProtoId)
+        => new() { ["Default"] = selectedProtoId };
+
+    [Test]
+    public void ChameleonClothing_DefaultPrototypeSurvivesRoundTrip()
+    {
+        var props = MakeChameleonProps("ClothingHeadHelmetHardsuitSecurity");
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!["Default"]?.ToString(), Is.EqualTo("ClothingHeadHelmetHardsuitSecurity"),
+            "Chameleon selected prototype ID must survive round-trip unchanged");
+    }
+
+    [Test]
+    public void ChameleonClothing_EmptyDefaultProducesNoEntry()
+    {
+        // SerializeChameleonClothingComponent returns null when Default is null/empty,
+        // so no ComponentData is added. Verify the guard logic matches.
+        var nullDefault = (string?)null;
+        var emptyDefault = string.Empty;
+
+        Assert.That(string.IsNullOrEmpty(nullDefault), Is.True, "null Default must be treated as not set");
+        Assert.That(string.IsNullOrEmpty(emptyDefault), Is.True, "empty Default must be treated as not set");
+    }
+
+    [Test]
+    public void ChameleonClothing_ProtoIdWithSpecialCharactersSurvivesRoundTrip()
+    {
+        // Prototype IDs can contain underscores, digits, and mixed case.
+        var props = MakeChameleonProps("ClothingOuterHardsuitRd_Variant2");
+        var yaml = Serializer.Serialize(props);
+        var restored = Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+
+        Assert.That(restored!["Default"]?.ToString(), Is.EqualTo("ClothingOuterHardsuitRd_Variant2"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // ToggleableClothing / helmet fix — AttachedUid sentinel logic
+    // ---------------------------------------------------------------------------
+
+    [Test]
+    public void ToggleableClothing_InvalidEntityUidSentinelIsNotValid()
+    {
+        // The helmet fix works by setting AttachedClothingComponent.AttachedUid = EntityUid.Invalid
+        // before deleting the auto-spawned helmet. OnRemoveAttached then calls
+        // TryComp(component.AttachedUid, ...) which returns false for an invalid uid,
+        // so ToggleableClothingComponent is NOT stripped from the suit.
+        //
+        // This test verifies the sentinel value behaves as expected.
+        var invalid = Robust.Shared.GameObjects.EntityUid.Invalid;
+        Assert.That(invalid.IsValid(), Is.False,
+            "EntityUid.Invalid must not be valid — the OnRemoveAttached guard relies on this");
+    }
+
+    [Test]
+    public void ToggleableClothing_DefaultEntityUidIsInvalid()
+    {
+        // A default (zero) EntityUid is equivalent to Invalid. This is the state
+        // AttachedUid would be in before assignment, confirming the sentinel doesn't
+        // accidentally alias a real entity.
+        var defaultUid = default(Robust.Shared.GameObjects.EntityUid);
+        Assert.That(defaultUid.IsValid(), Is.False,
+            "default EntityUid must not be valid");
+        Assert.That(defaultUid, Is.EqualTo(Robust.Shared.GameObjects.EntityUid.Invalid),
+            "default EntityUid must equal EntityUid.Invalid");
+    }
 }

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -11,6 +11,7 @@
     tags:
       - Payload
       - ClothMade
+      - RoomSaveable
   - type: EmitSoundOnUse
     sound:
       collection: ToySqueak

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -34,6 +34,9 @@
   - type: ContainerContainer
     containers:
       stash: !type:ContainerSlot {}
+  - type: Tag
+    tags:
+      - RoomSaveable
   - type: Pullable
   - type: Damageable
     damageContainer: StructuralInorganic # The pot. Not the plant. Or is it plastic?

--- a/Resources/Prototypes/_HL/Entities/Objects/Fun/pillows.yml
+++ b/Resources/Prototypes/_HL/Entities/Objects/Fun/pillows.yml
@@ -10,6 +10,7 @@
     tags:
       - Payload
       - ClothMade
+      - RoomSaveable
   - type: EmitSoundOnCollide
     sound:
       collection: ToyFall

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1222,6 +1222,9 @@
   id: RollingPin
 
 - type: Tag
+  id: RoomSaveable # Unanchored items with this tag are preserved in room saves
+
+- type: Tag
   id: SaltShaker
 
 - type: Tag


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Overhauls room save/load: fixes multi-second freezes, ~4 MB file bloat, lost component state, and unanchored item contamination.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bring apartment serialisation closer to ship serialisation.

## Technical details
<!-- Summary of code changes for easier review. -->

**Performance:**
- `roomMode` flag skips ~8,100 useless `ISerializationManager.WriteValue` reflection calls during room serialization — eliminates server-side freeze
- Client disk write moved to `Task.Run` — eliminates client-side freeze
- `RemoveAll(!c.Properties.Any())` strips empty component entries — shrinks saves from ~4 MB to ~50 KB

**New component round-trips** (all use a `Properties`-dict path, bypassing the broken DataNode path):
- `SprayPaintedComponent` — painted prototype/style; `RoomGridSpawnerSystem` now stamps the live `PaintableVisuals.Prototype` appearance data back onto the component before serializing so the correct style is captured
- `MaterialStorageComponent` — stored material stacks
- `StorageComponent` — item positions within storage (bags, crates, etc.)
- `StackComponent` — stack count
- `PaintedComponent` — color, shader, enabled state
- `LabelComponent` — custom label text
- `PaperComponent` — written content, stamp list (name/color/type/reapply), editing lock, stamp visual state
- `RandomSpriteComponent` — selected layer states and per-layer colors, preventing re-randomization on load
- `SerializeChameleonClothingComponent` — chameleon clothing retain appearance
- `DisconnectAttachedClothing` — suits don't lose helmets

**Sanitization:**
- Added `RoomSaveRules` static class (mirrors `ShipSaveYamlSanitizer`) with three sets: `FilteredPrototypes` (ContainmentField, portals, ShipShield), `EntityExclusionComponentNames` (ghosts, mobs, players), and `FilteredComponentNames` (JointComponent, StationMemberComponent, NavMapComponent, DeviceNetworkComponent, and ~15 others)
- New `RoomSaveable` tag gates the unanchored-item second pass — tools/weapons/spray painters are dropped; `BasePlushie`, `BasePillow`, and `PottedPlantBase` receive the tag

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

Existing saves remain loadable.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Room saves no longer freeze the game on save or load
- fix: Room save files shrunk from ~4 MB to ~50 KB
- fix: Spray-painted walls and objects now preserve their style after a room load
- fix: Material silo contents are now preserved after a room load
- fix: Item positions inside bags and crates are now preserved after a room load
- fix: Stack counts are now preserved after a room load
- fix: Paint colors (PaintedComponent), item labels, paper content/stamps, and plushie appearances now survive room loads
- fix: Unanchored tools and equipment are no longer saved in rooms (and turning non-interactable); only items tagged `RoomSaveable` (plushies, pillows, potted plants) are kept
- add: `RoomSaveable` tag — add to any prototype to preserve it when unanchored in a room save
