### PR TITLE
Fix shadekin (and synth) foam interaction

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -273,7 +273,7 @@ public sealed class SmokeSystem : EntitySystem
         if (!_solutionContainerSystem.ResolveSolution(entity, bloodstream.ChemicalSolutionName, ref bloodstream.ChemicalSolution, out var chemSolution) || chemSolution.AvailableVolume <= 0)
             return;
 
-        var blockIngestion = _internals.AreInternalsWorking(entity);
+        var blockIngestion = _internals.AreInternalsWorking(entity) || !HasComp<RespiratorComponent>(entity);
 
         var cloneSolution = solution.Clone();
         var availableTransfer = FixedPoint2.Min(cloneSolution.Volume, component.TransferRate);


### PR DESCRIPTION

## About the PR
Shadekin now don't inhale foam, only get smeared in it if applicable.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Shadekin don't breathe and thus shouldn't ingest foam per the comments in the source code.
Foam is inhaled because just wearing mask or helmet isn't enough -- internals must be on (which isn't possible for shadekin).

## Technical details
<!-- Summary of code changes for easier review. -->
Just a simple check inside smoke system for `RespiratorComponent` -- same used in internals.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn shadekin, spawn foam, see shadekin ignest no foam but still get skin covered in it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Nothing I've noticed.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Shadekin don't inhale foam any more