### PR TITLE
Re-enable STC

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -20,7 +20,7 @@
         lobbySortOrder: 1
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,6 +29,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -17,7 +17,7 @@
       #   emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -26,6 +26,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -16,7 +16,7 @@
       #   emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -25,6 +25,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -19,7 +19,7 @@
         lobbySortOrder: 1
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -28,6 +28,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -20,7 +20,7 @@
         lobbySortOrder: 1
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,6 +29,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -19,7 +19,7 @@
       #   path: /Maps/Shuttles/cargo_elkridge.yml
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -28,6 +28,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -18,7 +18,7 @@
         path: /Maps/Shuttles/cargo_fland.yml
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -27,6 +27,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -20,7 +20,7 @@
         lobbySortOrder: 1
       - type: StationJobs # HardLight: Reordered + additions added
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,6 +29,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/_HL/Maps/core.yml
+++ b/Resources/Prototypes/_HL/Maps/core.yml
@@ -20,7 +20,7 @@
         lobbySortOrder: 1
       - type: StationJobs
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,6 +29,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/_HL/Maps/eaglerock.yml
+++ b/Resources/Prototypes/_HL/Maps/eaglerock.yml
@@ -20,7 +20,7 @@
         lobbySortOrder: 1
       - type: StationJobs
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -29,6 +29,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/_HL/Maps/silica.yml
+++ b/Resources/Prototypes/_HL/Maps/silica.yml
@@ -15,7 +15,7 @@
         #   prefixCreator: 'CW'
       - type: StationJobs
         availableJobs:
-          # Command (8)
+          # Command (9)
           StationCaptain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
@@ -24,6 +24,7 @@
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
           StationRepresentative: [ 1, 1 ] # Harbor Master
+          StationTrafficController: [ 1, 1 ]
           # Silicon (2)
           StationAi: [ 1, 1 ]
           Borg: [ 3, 3 ]

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -74,6 +74,7 @@
   - External
   - Brig
   - Frontier
+  - StationTrafficController
   - Mercenary
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
@@ -13,10 +13,10 @@
       time: 10800 # 3 hrs
   canBeAntag: false
   icon: "JobIconStc"
-  supervisors: job-supervisors-captain
-  weight: 160
-  displayWeight: 50 # Second from the top
-  setPreference: false # HardLight: true<false
+  supervisors: job-supervisors-sr # HardLight: -captain<-sr
+  weight: 0 # HardLight: 160<0
+  # displayWeight: 50 # Second from the top
+  setPreference: true
   access:
   - Command # HardLight
   - Service
@@ -24,6 +24,7 @@
   - External
   - Brig # HardLight
   - Frontier
+  - StationTrafficController
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/departments.yml
@@ -7,6 +7,7 @@
   roles:
   - StationRepresentative
   # HardLight start
+  - StationTrafficController
   - Mercenary
   - Pilot
   - Contractor


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Re-enables STC as a subordinate of the Harbor Master. Correctly gives STC access to their traffic consoles. And also gives Harbor Master access to the traffic consoles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Harbor Masters have to deal with 40 people on a consistent basis. As such, Harbor Masters have a lot to deal with, and due to name alone, people also expect them to act like the STC. 

Not only does re-enabling STC take some of the weight off of the HM's shoulders, but it also gives another role for people on station to play. 

It's a win-win.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: STC can once again be selected as a round-start job.
- add: The HM can now access traffic control consoles.
- fix: The STC now correctly has access to traffic control consoles.
