### PR TITLE
Revert "fix diagonal walls not occluding (#1713)"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -629,7 +629,6 @@
     snap:
     - Wall
   components:
-  - type: Occluder # Hardlight: occlusion
   - type: Transform
     anchored: true
   - type: Clickable


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Reverts #1713

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I haven't seen anyone but the publisher of #1713 not complain about occlusions being turned on for diagonal walls. Yes, the alternative is that they're see-through, but see-through is better than them blocking your entire view because diagonal occluders don't exist on the RobustToolbox.

Until they do, diagonal walls should not be given occluders.

<img width="1100" height="1178" alt="image" src="https://github.com/user-attachments/assets/decedfb4-cb31-4f65-a5ff-540b859c46b5" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Diagonal walls no longer occlude.
