### PR TITLE
Fix Wooden Television Using Modular Console Sprite

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -14,6 +14,16 @@
       state: detective_television
   - type: Computer
     board: ComputerTelevisionCircuitboard
+  # HardLight start
+  - type: GenericVisualizer
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: television, sprite: Structures/Machines/computers.rsi }
+          West: { state: television, sprite: Structures/Machines/computers.rsi }
+          East: { state: television, sprite: Structures/Machines/computers.rsi }
+          East, West: { state: television, sprite: Structures/Machines/computers.rsi }
+  # HardLight end
   - type: PointLight
     radius: 1.5
     energy: 1.6


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Quick fix.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Wooden televisions should no longer incorrectly use modular console sprites.
