### PR TITLE
Add New Alt+Click Interactions

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -61,6 +61,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             SubscribeLocalEvent<GasVentPumpComponent, GasAnalyzerScanEvent>(OnAnalyzed);
             SubscribeLocalEvent<GasVentPumpComponent, WeldableChangedEvent>(OnWeldChanged);
             SubscribeLocalEvent<GasVentPumpComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
+            SubscribeLocalEvent<GasVentPumpComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
             SubscribeLocalEvent<GasVentPumpComponent, VentScrewedDoAfterEvent>(OnVentScrewed);
         }
 
@@ -387,7 +388,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnGetVerbs(Entity<GasVentPumpComponent> ent, ref GetVerbsEvent<Verb> args)
         {
-            if (ent.Comp.UnderPressureLockout == false || !Transform(ent).Anchored)
+            if (!CanAddReleaseLockoutVerb(ent)) // HardLight
                 return;
 
             var user = args.User;
@@ -399,22 +400,51 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 Text = Loc.GetString("gas-vent-pump-release-lockout"),
                 Impact = LogImpact.Low,
                 DoContactInteraction = true,
-                Act = () =>
-                {
-                    var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.ManualLockoutDisableDoAfter, new VentScrewedDoAfterEvent(), ent, ent)
-                    {
-                        BreakOnDamage = true,
-                        NeedHand = true,
-                        BreakOnMove = true,
-                        BreakOnWeightlessMove = true,
-                    };
+                Act = () => TryStartReleaseLockoutDoAfter(ent, user), // HardLight
+            };
 
-                    _doAfterSystem.TryStartDoAfter(doAfter);
-                },
+            args.Verbs.Add(v); // HardLight
+        }
+
+        // HardLight start
+        private void OnGetAltVerbs(Entity<GasVentPumpComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+        {
+            if (!CanAddReleaseLockoutVerb(ent) || !args.CanAccess || !args.CanInteract || args.Hands == null)
+                return;
+
+            var user = args.User;
+
+            var v = new AlternativeVerb
+            {
+                Priority = 1,
+                Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/unlock.svg.192dpi.png")),
+                Text = Loc.GetString("gas-vent-pump-release-lockout"),
+                Impact = LogImpact.Low,
+                DoContactInteraction = true,
+                Act = () => TryStartReleaseLockoutDoAfter(ent, user),
             };
 
             args.Verbs.Add(v);
         }
+
+        private bool CanAddReleaseLockoutVerb(Entity<GasVentPumpComponent> ent)
+        {
+            return ent.Comp.UnderPressureLockout && Transform(ent).Anchored;
+        }
+
+        private void TryStartReleaseLockoutDoAfter(Entity<GasVentPumpComponent> ent, EntityUid user)
+        {
+            var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.ManualLockoutDisableDoAfter, new VentScrewedDoAfterEvent(), ent, ent)
+            {
+                BreakOnDamage = true,
+                NeedHand = true,
+                BreakOnMove = true,
+                BreakOnWeightlessMove = true,
+            };
+
+            _doAfterSystem.TryStartDoAfter(doAfter);
+        }
+        // HardLight end
 
         private void OnVentScrewed(EntityUid uid, GasVentPumpComponent component, VentScrewedDoAfterEvent args)
         {

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [Clothing, RecyclableItemClothSmall] # Frontier: added RecyclableItemClothSmall
+  parent: [ Clothing, RecyclableItemClothSmall ] # Frontier: added RecyclableItemClothSmall
   id: ClothingShoesBase
   components:
   - type: Clothing
@@ -39,7 +39,7 @@
 # stuff common to all military boots
 - type: entity
   abstract: true
-  parent: [ClothingShoesBase, ClothingSlotBase]
+  parent: [ ClothingShoesBase, ClothingSlotBase ]
   id: ClothingShoesMilitaryBase
   components:
   - type: Matchbox
@@ -47,6 +47,7 @@
     slots:
       item:
         name: clothing-boots-sidearm
+        priority: 1 # HardLight
         whitelist:
           tags:
           - Knife


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes alt+click release pressure-locked air vents and makes the eject knife attempt trigger before other possible actions.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Alt+Click now releases pressure-locked air vents.
- tweak: Alt+Click now attempts to eject knives before other possible actions (i.e. opening the valve for magboots with gas containers and item slots).
