### PR TITLE
Improvised ammo fix+ flares craftable

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Boxes/improvised.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Boxes/improvised.yml
@@ -99,7 +99,7 @@
   name: improvised ammunition box (12 gauge improvised)
   components:
   - type: BallisticAmmoProvider
-    proto: ShellShotgunImprovised
+    proto: ShellShotgun12_gaugeImprovised
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -162,6 +162,7 @@
   - AmmoBox12_gaugeIncendiary
   - AmmoBox12_gaugePractice
   - AmmoBox12_gaugeUranium
+  - AmmoBox12_gaugeFlare
   - Magazine45_ACPSubMachineGunTopMountedFMJ
   - Magazine45_ACPSubMachineGunTopMountedEmpty
   - Magazine9x19mmSubMachineGunTopMountedFMJ
@@ -230,7 +231,7 @@
   - Magazine8x65mmEmpty
   - Magazine762x54mmREmpty
   - Magazine762x51mmEmpty
-  - Magazine12_gaugeEmpty 
+  - Magazine12_gaugeEmpty
   - Magazine45_ACPSubMachineGunTopMountedEmpty
   - Magazine9x19mmSubMachineGunTopMountedEmpty
   - Magazine57x28mmSubMachineGunTopMountedEmpty


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
just a small change to make improvised shotgunshell boxes to actually be usable with our shotguns, and 12 gauge flares are now craftable
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the other boxes are tagged right but the shotgun shells arent, also 12 gauge flares are in the code but not craftable for some bizzaro reason
## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
