### PR TITLE
fixed the value for plastitanium walls and windows

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -588,6 +588,8 @@
     - type: IconSmooth
       key: walls
       base: plastitanium
+    - type: StaticPrice
+      price: 250
 
 
 - type: entity
@@ -762,6 +764,8 @@
   - type: ShipRepairable
     repairTime: 20
     repairCost: 50
+  - type: StaticPrice
+    price: 250
 
 - type: entity
   id: WallPlastitaniumDiagonalIndestructible
@@ -816,6 +820,8 @@
   - type: ShipRepairable
     repairTime: 20
     repairCost: 50
+  - type: StaticPrice
+    price: 250
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -118,14 +118,14 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: RGlass
-  - type: StaticPrice
-    price: 100
   - type: Construction
     graph: Plastitanium
     node: plastitaniumWindow
   - type: ShipRepairable
     repairTime: 20
     repairCost: 50
+  - type: StaticPrice
+    price: 250
 
 - type: entity
   id: PlastitaniumWindowDiagonalBase
@@ -231,3 +231,6 @@
   - type: ShipRepairable
     repairTime: 20
     repairCost: 50
+  - type: StaticPrice
+    price: 250
+


### PR DESCRIPTION

## About the PR
Plastitanium structures had no set price (except for windows at 100)
Since reinforced walls cost 115 and shuttle walls cost 150, 250 seems like a good balanced price point

## Why / Balance
Plastitanium was one of the cheapest structures to load.

## Technical details
Added StaticPrices to the plastitanium family of walls/windows

## How to test
* Spawn plastitanium walls and windows
* use an appraisal tool


:cl:
- fix: Fixed plastitanium structure cost to 250

