### PR TITLE
Fix playtime requirements for some service roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -6,7 +6,7 @@
   setPreference: true
   requirements:
     - !type:DepartmentTimeRequirement
-      department: Civilian
+      department: Service # Hardlight Civilian > Service
       time: 1800 # 0.5 hrs
   weight: 40 # HardLight
   startingGear: BartenderGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -6,7 +6,7 @@
   setPreference: true
   requirements:
     - !type:DepartmentTimeRequirement
-      department: Civilian
+      department: Service # Hardlight Civilian > Service
       time: 1800 # 0.5 hr
   weight: 60 # HardLight
   startingGear: ChefGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobServiceWorker
   requirements:
   - !type:DepartmentTimeRequirement
-    department: Civilian
+    department: Service # Hardlight Civilian > Service
     time: 1800 # 0.5 hr
   weight: 20 # HardLight
   startingGear: ServiceWorkerGear


### PR DESCRIPTION
## About the PR
Fixes the playtime requirements for bartender, chef and service worker.
Closes #1587

## Why / Balance
Bugfix

## Technical details
They were coded to be a part of the civilian department, not service.

## How to test
Build on release, play a service role for a while, see that playtime updates for the aforementioned roles 


**Changelog**
:cl:
- fix: Fixed some service roles not recording playtime
