### PR TITLE
Port WizDen Station Map Improvements

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
@@ -6,33 +6,33 @@
   placement:
     mode: SnapgridCenter
   components:
-    - type: InteractionOutline
-    - type: Clickable
-    - type: Transform
-      anchored: true
-    - type: Sprite
-      sprite: Structures/Machines/station_map.rsi
-      drawdepth: WallMountedItems
-      layers:
-        - state: station_map_broken
-    - type: Damageable
-      damageContainer: StructuralInorganic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:PlaySoundBehavior
-              sound:
-                collection: GlassBreak
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-    # Mono
-    - type: ShipRepairable
-      repairTo: StationMap
-      repairTime: 3
-      repairCost: 6
+  - type: InteractionOutline
+  - type: Clickable
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: Structures/Machines/station_map.rsi
+    drawdepth: WallMountedItems
+    layers:
+    - state: station_map_broken
+  - type: Damageable
+    damageContainer: StructuralInorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  # Mono
+  - type: ShipRepairable
+    repairTo: StationMap
+    repairTime: 3
+    repairCost: 6
 
 - type: entity
   id: StationMap
@@ -43,73 +43,77 @@
   placement:
     mode: SnapgridCenter
   components:
-    - type: StationMap
-    - type: EdgeConnection # HardLight
-      connectionKey: wallmount_computers
-      allowedDirections: East, West
-    - type: Transform
-      anchored: true
-    - type: Sprite
-      sprite: Structures/Machines/station_map.rsi
-      layers:
-      - map: [ "computerLayerBody" ]
-        state: station_map0
-      - map: [ "computerLayerScreen" ]
-        state: unshaded
-    # HardLight start
-    - type: GenericVisualizer
-      visuals:
-        enum.EdgeConnectionVisuals.ConnectionMask:
-          computerLayerBody:
-            None: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
-            West: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
-            East: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
-            East, West: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
-    # HardLight end
-    - type: Icon
-      sprite: Structures/Machines/station_map.rsi
+  - type: StationMap
+  - type: EdgeConnection # HardLight
+    connectionKey: wallmount_computers
+    allowedDirections: East, West
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: Structures/Machines/station_map.rsi
+    layers:
+    - map: [ "computerLayerBody" ]
       state: station_map0
-    - type: ContainerFill
-      containers:
-        board: [ StationMapCircuitboard ]
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-    - type: ApcPowerReceiver
-      powerLoad: 200
-    - type: WallMount
-      arc: 360
-    - type: ExtensionCableReceiver
-    - type: Construction
-      graph: StationMap
-      node: station_map
-    - type: ActivatableUIRequiresPower
-    - type: ActivatableUI
-      key: enum.StationMapUiKey.Key
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:PlaySoundBehavior
-              sound:
-                collection: GlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                StationMapBroken:
-                  min: 1
-                  max: 1
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-    - type: UserInterface
-      interfaces:
-        enum.StationMapUiKey.Key:
-          type: StationMapBoundUserInterface
-    # Mono
-    - type: ShipRepairable
-      repairTime: 3
-      repairCost: 6
+    - map: [ "computerLayerScreen" ]
+      state: unshaded
+  - type: Icon
+    sprite: Structures/Machines/station_map.rsi
+    state: station_map0
+  - type: GenericVisualizer
+    visuals:
+      # HardLight start
+      enum.ComputerVisuals.Powered:
+        computerLayerScreen:
+          True: { visible: true, shader: unshaded }
+          False: { visible: false }
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
+          West: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
+          East: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
+          East, West: { state: station_map0, sprite: Structures/Machines/station_map.rsi }
+      # HardLight end
+  - type: ContainerFill
+    containers:
+      board: [ StationMapCircuitboard ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+  - type: ApcPowerReceiver
+    powerLoad: 200
+  - type: WallMount
+    arc: 360
+  - type: ExtensionCableReceiver
+  - type: Construction
+    graph: StationMap
+    node: station_map
+  - type: ActivatableUIRequiresPower
+  - type: ActivatableUI
+    key: enum.StationMapUiKey.Key
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          StationMapBroken:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: UserInterface
+    interfaces:
+      enum.StationMapUiKey.Key:
+        type: StationMapBoundUserInterface
+  # Mono
+  - type: ShipRepairable
+    repairTime: 3
+    repairCost: 6
 
 - type: entity
   id: StationMapAssembly

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_wallmount.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_wallmount.yml
@@ -1,52 +1,80 @@
 # Mass scanner telescreen
 - type: entity
-  parent: [BaseStructureComputerWallmount, ComputerRadar]
+  parent: [ BaseStructureComputerWallmount, ComputerRadar ]
   id: ComputerWallmountRadar
   components:
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: _NF/Structures/Machines/computer_wallmount.rsi
     layers:
-    - map: ["computerLayerBody"]
+    - map: [ "computerLayerBody" ]
       state: computer_wallmount
-    - map: ["computerLayerScreen"]
+    - map: [ "computerLayerScreen" ]
       state: screen_mass
+  # HardLight start
+  - type: GenericVisualizer
+    visuals:
+      enum.ComputerVisuals.Powered:
+        computerLayerScreen:
+          True: { visible: true, shader: unshaded }
+          False: { visible: false }
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: computer_wallmount }
+          West: { state: computer_wallmount }
+          East: { state: computer_wallmount }
+          East, West: { state: computer_wallmount }
+  # HardLight end
 
 - type: entity
-  parent: [BaseStructureComputerWallmount, ComputerAdvancedRadar]
+  parent: [ BaseStructureComputerWallmount, ComputerAdvancedRadar ]
   id: ComputerWallmountAdvancedRadar
   components:
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: _NF/Structures/Machines/computer_wallmount.rsi
     layers:
-    - map: ["computerLayerBody"]
+    - map: [ "computerLayerBody" ]
       state: computer_wallmount
-    - map: ["computerLayerScreen"]
+    - map: [ "computerLayerScreen" ]
       state: screen_radar
+  # HardLight start
+  - type: GenericVisualizer
+    visuals:
+      enum.ComputerVisuals.Powered:
+        computerLayerScreen:
+          True: { visible: true, shader: unshaded }
+          False: { visible: false }
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        computerLayerBody:
+          None: { state: computer_wallmount }
+          West: { state: computer_wallmount }
+          East: { state: computer_wallmount }
+          East, West: { state: computer_wallmount }
+  # HardLight end
 
 - type: entity
-  parent: [BaseStructureComputerWallmount, ComputerStationRecords]
+  parent: [ BaseStructureComputerWallmount, ComputerStationRecords ]
   id: ComputerWallmountStationRecords
   components:
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: _NF/Structures/Machines/computer_wallmount.rsi
     layers:
-    - map: ["computerLayerBody"]
+    - map: [ "computerLayerBody" ]
       state: computer_wallmount
-    - map: ["computerLayerScreen"]
+    - map: [ "computerLayerScreen" ]
       state: screen_records
 
 - type: entity
-  parent: [BaseStructureComputerWallmount, ComputerCrewMonitoring]
+  parent: [ BaseStructureComputerWallmount, ComputerCrewMonitoring ]
   id: ComputerWallmountCrewMonitoring
   components:
   - type: Sprite
     drawdepth: WallMountedItems
     sprite: _NF/Structures/Machines/computer_wallmount.rsi
     layers:
-    - map: ["computerLayerBody"]
+    - map: [ "computerLayerBody" ]
       state: computer_wallmount
-    - map: ["computerLayerScreen"]
+    - map: [ "computerLayerScreen" ]
       state: screen_crew


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ports:
https://github.com/space-wizards/space-station-14/pull/39393
https://github.com/space-wizards/space-station-14/pull/43877

Makes station maps correctly unshaded and gives them an unpowered visual state. QoL when powered AND unpowered!

Also does the same for the wallmount mass scanners and advanced radars added by Frontier.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It just looks nicer this way.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Wallmount station maps, mass scanners, and advanced radars now correctly glow in the dark.
- add: Wallmount station maps, mass scanners, and advanced radars now correctly reflect state when unpowered.