### PR TITLE
Fix Meteors Instantly Colliding w/ Grids & Spawning Inside Grids

### DIFF
--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Server._Hardlight.StationEvents.Events;
+using Content.Server._NF.Station.Components; // HardLight
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Components;
@@ -9,6 +10,8 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
 using Robust.Server.Audio;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components; // HardLight
+using Robust.Shared.Maths;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
@@ -18,6 +21,10 @@ namespace Content.Server.StationEvents.Events;
 
 public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 {
+    private const int SpawnClearanceAttempts = 6; // HardLight
+    private const float SpawnClearanceMargin = 25f; // HardLight
+
+    [Dependency] private readonly IMapManager _mapManager = default!; // HardLight
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
@@ -28,6 +35,7 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         base.Added(uid, component, gameRule, args);
 
         component.WaveCounter = component.Waves.Next(RobustRandom);
+        component.NextWaveTime = Timing.CurTime + TimeSpan.FromSeconds(component.WaveCooldown.Next(RobustRandom)); // HardLight
 
         // we don't want to send to players who aren't in game (i.e. in the lobby)
         Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
@@ -45,16 +53,28 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 
         component.NextWaveTime += TimeSpan.FromSeconds(component.WaveCooldown.Next(RobustRandom));
 
-        // Hardlight: filter by ValidMeteorSwarmComponent to prevent ships from being hit
-        var stations = _station.GetStations()
-            .FindAll(it => it.Valid && HasComp<ValidMeteorSwarmComponent>(it));
+        // HardLight: Only target actual station body grids, not attached/purchased shuttles.
+        var candidates = new List<(EntityUid Station, EntityUid Grid)>();
+        foreach (var station in _station.GetStations())
+        {
+            if (!station.Valid ||
+                !HasComp<ValidMeteorSwarmComponent>(station) ||
+                HasComp<ExtraShuttleInformationComponent>(station))
+                continue;
 
-        if (stations.Count == 0)
+            if (!TryComp<StationDataComponent>(station, out var stationData))
+                continue;
+
+            if (TryGetMeteorTargetGrid(stationData) is not { } targetGrid)
+                continue;
+
+            candidates.Add((station, targetGrid));
+        }
+
+        if (candidates.Count == 0) // HardLight
             return;
 
-        var station = RobustRandom.Pick(stations);
-        if (_station.GetLargestGrid(Comp<StationDataComponent>(station)) is not { } grid)
-            return;
+        var (_, grid) = RobustRandom.Pick(candidates); // HardLight
 
         var mapId = Transform(grid).MapID;
         var playableArea = _physics.GetWorldAABB(grid);
@@ -82,7 +102,7 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
                 : angle - Math.PI / 2;
             var subOffset = subOffsetAngle.RotateVec(new Vector2( (playableArea.TopRight - playableArea.Center).Length() / 3 * RobustRandom.NextFloat(), 0));
 
-            var spawnPosition = new MapCoordinates(center + offset + subOffset, mapId);
+            var spawnPosition = FindSpawnPosition(center, mapId, offset, subOffset); // HardLight
             var meteor = Spawn(spawnProto, spawnPosition);
             var physics = Comp<PhysicsComponent>(meteor);
             _physics.ApplyLinearImpulse(meteor, -offset.Normalized() * component.MeteorVelocity * physics.Mass, body: physics);
@@ -93,5 +113,62 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         {
             ForceEndSelf(uid, gameRule);
         }
+    }
+
+    private EntityUid? TryGetMeteorTargetGrid(StationDataComponent stationData) // HardLight
+    {
+        EntityUid? largestGrid = null;
+        var largestSize = 0f;
+
+        foreach (var gridUid in stationData.Grids)
+        {
+            if (!TryComp<MapGridComponent>(gridUid, out var grid))
+            {
+                continue;
+            }
+
+            var size = grid.LocalAABB.Size.LengthSquared();
+            if (size <= largestSize)
+                continue;
+
+            largestSize = size;
+            largestGrid = gridUid;
+        }
+
+        return largestGrid;
+    }
+
+    private MapCoordinates FindSpawnPosition(Vector2 center, MapId mapId, Vector2 offset, Vector2 subOffset) // HardLight
+    {
+        var outwardDirection = offset.Normalized();
+        var spawnPosition = center + offset + subOffset;
+
+        for (var attempt = 0; attempt < SpawnClearanceAttempts; attempt++)
+        {
+            if (!_mapManager.TryFindGridAt(mapId, spawnPosition, out var blockingGrid, out _))
+                return new MapCoordinates(spawnPosition, mapId);
+
+            spawnPosition += outwardDirection * GetPushOutDistance(blockingGrid, spawnPosition, outwardDirection);
+        }
+
+        return new MapCoordinates(spawnPosition, mapId);
+    }
+
+    private float GetPushOutDistance(EntityUid blockingGrid, Vector2 spawnPosition, Vector2 outwardDirection) // HardLight
+    {
+        var blockingBounds = _physics.GetWorldAABB(blockingGrid);
+        var furthestProjection = GetFurthestProjection(blockingBounds, outwardDirection);
+        var currentProjection = Vector2.Dot(spawnPosition, outwardDirection);
+
+        return MathF.Max(furthestProjection - currentProjection, 0f) + SpawnClearanceMargin;
+    }
+
+    private static float GetFurthestProjection(Box2 bounds, Vector2 direction) // HardLight
+    {
+        var furthest = Vector2.Dot(bounds.BottomLeft, direction);
+        furthest = MathF.Max(furthest, Vector2.Dot(bounds.BottomRight, direction));
+        furthest = MathF.Max(furthest, Vector2.Dot(bounds.TopLeft, direction));
+        furthest = MathF.Max(furthest, Vector2.Dot(bounds.TopRight, direction));
+        return furthest;
     }
 }

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -236,6 +236,28 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             vesselInfo.Vessel = vessel.ID;
         }
 
+        // HardLight start
+        // Purchased ships get added to the console station briefly for docking setup.
+        // Remove that stale membership once the ship has its own station so event targeting
+        // and other station-wide logic don't keep treating it as part of the outpost.
+        try
+        {
+            var consoleStation = _station.GetOwningStation(shipyardConsoleUid);
+            if (consoleStation != null &&
+                shuttleStation != null &&
+                consoleStation != shuttleStation &&
+                TryComp<StationMemberComponent>(shuttleUid, out var member) &&
+                member.Station == shuttleStation)
+            {
+                _station.RemoveGridFromStation(consoleStation.Value, shuttleUid);
+            }
+        }
+        catch (Exception rmEx)
+        {
+            Log.Warning($"[ShipPurchase(Console)] Failed to remove stale station membership from {ToPrettyString(shuttleUid)}: {rmEx.Message}");
+        }
+        // HardLight end
+
         if (TryComp<AccessComponent>(targetId, out var newCap))
         {
             var newAccess = newCap.Tags.ToList();


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes meteors spawning instantly when the space dust event triggers, meaning they should no longer already be colliding with the station when Colonial Command announces them.

Potentially fixes meteors spawning inside grids and instantly exploding.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Meteors are supposed to... act like meteors. Now they kind of do.

## Technical details
<!-- Summary of code changes for easier review. -->
Adjusted meteor swarm timing and targeting so waves no longer hit instantly on alert, no longer select vessel stations as targets, and clean up purchased-ship station membership that could misdirect impacts. Meteor spawn clearance now checks for blocking grids and pushes spawn points beyond obstructing ship/grid bounds instead of spawning inside them.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
In a dev env, spawn some shit around the station (i.e. docks, ships, xenos, etc), and then run several addgamerule gamerulespacedustmajor and observe the meteors. You'll notice they don't immediately crash into the station on event trigger and... you shouldn't notice any spawning inside any of the grids located around the station.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
The station.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Meteors no longer instantly impact with the station upon being alerted of their "incoming" presence.
- fix: Meteors should no longer spawn and immediately explode inside grids located around the station.
