### PR TITLE
Restrict Medical Tracking Implant Emergency Extractions to Expeditions

### DIFF
--- a/Content.Server/_NF/Implants/MedicalTeleportImplantSystem.cs
+++ b/Content.Server/_NF/Implants/MedicalTeleportImplantSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Implants;
 using Content.Server.Radio.EntitySystems;
+using Content.Server.Salvage.Expeditions;
 using Content.Shared._HL.Rescue.Rescue;
 using Content.Shared._NF.Implants.Components;
 using Content.Shared.Humanoid;
@@ -23,8 +24,10 @@ namespace Content.Server._NF.Implants;
 
 /// <summary>
 /// Handles delayed teleportation for entities implanted with <see cref="MedicalTeleportImplantComponent"/>.
-/// When the implanted owner dies, a fulton-like extraction is scheduled for 10 seconds later. If the owner
-/// is revived before the timer elapses, the extraction is canceled.
+// HardLight start
+/// When the implanted owner dies on a salvage expedition map, a fulton-like extraction is scheduled.
+/// If the owner is revived before the timer elapses, the extraction is canceled.
+// HardLight end
 /// </summary>
 public sealed class MedicalTeleportImplantSystem : EntitySystem
 {
@@ -108,6 +111,10 @@ public sealed class MedicalTeleportImplantSystem : EntitySystem
 
         // Only start when entering Dead state
         if (newState != MobState.Dead)
+            return;
+
+        // HardLight: Rescue extractions are expedition-only.
+        if (!IsOnExpedition(owner))
             return;
 
         // If no beacon, do nothing
@@ -248,5 +255,11 @@ public sealed class MedicalTeleportImplantSystem : EntitySystem
         }
 
         return best;
+    }
+
+    private bool IsOnExpedition(EntityUid owner) // HardLight
+    {
+        var mapUid = Transform(owner).MapUid;
+        return mapUid != null && HasComp<SalvageExpeditionComponent>(mapUid.Value);
     }
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Simple as. Makes the medical tracking implant only fulton on death if the target is on an expedition map.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parameds have nothing to do. Rescue shuttles have nothing to do. "Danger" is a mere concept.

Also, the people spoke and apparently this is what they wanted based on an extremely short-lived vote.

## Technical details
<!-- Summary of code changes for easier review. -->
Minor C# tweak that forces emergency extraction to require targets to occupy an expedition map.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Die on station. Die again on an expedition. Observe the differences.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Your life.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Medical tracking implants now only execute emergency extractions when the target is located on an expedition map.
