### PR TITLE
Fix Cloning/Admin Spawning Not Giving Traits

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Mind;
 using Content.Server.Mind.Commands;
 using Content.Server.Prayer;
 using Content.Server.Station.Systems;
+using Content.Server.Traits; // HardLight
 using Content.Shared.Administration;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
@@ -62,6 +63,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly StationSystem _stations = default!;
         [Dependency] private readonly StationSpawningSystem _spawning = default!;
+        [Dependency] private readonly TraitSystem _traits = default!; // HardLight
         [Dependency] private readonly ExamineSystemShared _examine = default!;
         [Dependency] private readonly AdminFrozenSystem _freeze = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -163,6 +165,7 @@ namespace Content.Server.Administration.Systems
 
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
                             var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid, session: targetActor.PlayerSession); // Frontier: added session
+                            _traits.ApplyProfileTraits(mobUid, profile, targetActor.PlayerSession.Name); // HardLight
 
                             if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
                                 _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
@@ -188,7 +191,8 @@ namespace Content.Server.Administration.Systems
                             var stationUid = _stations.GetOwningStation(args.Target);
 
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
-                            _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid, session: targetActor.PlayerSession); // Frontier: added session
+                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid, session: targetActor.PlayerSession); // Frontier: Added session, // HardLight: Added var mobUid =
+                            _traits.ApplyProfileTraits(mobUid, profile, targetActor.PlayerSession.Name); // HardLight
                         },
                         ConfirmationPopup = true,
                         Impact = LogImpact.High,

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -64,6 +64,8 @@ using Content.Server.DeviceLinking.Systems;
 using Content.Server.EUI;
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Humanoid;
+using Content.Server.Preferences.Managers; // HardLight
+using Content.Server.Traits; // HardLight
 using Content.Shared.Administration.Logs;
 using Content.Shared.Cloning;
 using Content.Shared.Cloning.Events;
@@ -73,6 +75,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Content.Shared.NameModifier.EntitySystems;
+using Content.Shared.Preferences; // HardLight
 using Content.Shared.StatusEffect;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
@@ -83,6 +86,8 @@ using Robust.Shared.Prototypes;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared._EinsteinEngines.Silicon.Components;
+using Content.Shared.Mind; // HardLight
+using Robust.Server.Player; // HardLight
 using Robust.Shared.Random;
 
 namespace Content.Server.Cloning;
@@ -103,6 +108,10 @@ public sealed partial class CloningSystem : EntitySystem
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedSubdermalImplantSystem _subdermalImplant = default!;
     [Dependency] private readonly NameModifierSystem _nameMod = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!; // HardLight
+    [Dependency] private readonly IServerPreferencesManager _prefs = default!; // HardLight
+    [Dependency] private readonly IPlayerManager _player = default!; // HardLight
+    [Dependency] private readonly TraitSystem _traits = default!; // HardLight
 
     /// <summary>
     ///     Spawns a clone of the given humanoid mob at the specified location or in nullspace.
@@ -131,6 +140,7 @@ public sealed partial class CloningSystem : EntitySystem
         _humanoidSystem.CloneAppearance(original, clone.Value);
 
         CloneComponents(original, clone.Value, settings);
+        ApplySelectedTraits(original, clone.Value); // HardLight
 
         // Add equipment first so that SetEntityName also renames the ID card.
         if (settings.CopyEquipment != null)
@@ -152,6 +162,23 @@ public sealed partial class CloningSystem : EntitySystem
 
         _adminLogger.Add(LogType.Chat, LogImpact.Medium, $"The body of {original:player} was cloned as {clone.Value:player}");
         return true;
+    }
+
+    private void ApplySelectedTraits(EntityUid original, EntityUid clone) // HardLight
+    {
+        if (!_mind.TryGetMind(original, out _, out var mind) ||
+            mind.UserId == null ||
+            _prefs.GetPreferences(mind.UserId.Value).SelectedCharacter is not HumanoidCharacterProfile profile)
+        {
+            return;
+        }
+
+        string? playerName = null;
+        if (_player.TryGetSessionById(mind.UserId.Value, out var session))
+            playerName = session.Name;
+
+        // Clone equipment separately; replay only the selected trait components here.
+        _traits.ApplyProfileTraits(clone, profile, playerName, addTraitGear: false);
     }
 
     /// <summary>
@@ -278,7 +305,7 @@ public sealed partial class CloningSystem : EntitySystem
             var mob = Spawn(speciesPrototype.Prototype, Transform(uid).MapPosition);
             _humanoidSystem.CloneAppearance(bodyToClone, mob);
 
-            ///Nyano - Summary: adds the potential psionic trait to the reanimated mob. 
+            ///Nyano - Summary: adds the potential psionic trait to the reanimated mob.
             EnsureComp<PotentialPsionicComponent>(mob);
 
             var ev = new CloningEvent(bodyToClone, mob);

--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -20,40 +20,6 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         SubscribeLocalEvent<HumanoidAppearanceComponent, GetVerbsEvent<Verb>>(OnVerbsRequest);
     }
 
-    // this was done enough times that it only made sense to do it here
-
-    /// <summary>
-    ///     Clones a humanoid's appearance to a target mob, provided they both have humanoid components.
-    /// </summary>
-    /// <param name="source">Source entity to fetch the original appearance from.</param>
-    /// <param name="target">Target entity to apply the source entity's appearance to.</param>
-    /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
-    /// <param name="targetHumanoid">Target entity's humanoid component.</param>
-    public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
-        HumanoidAppearanceComponent? targetHumanoid = null)
-    {
-        if (!Resolve(source, ref sourceHumanoid, false) || !Resolve(target, ref targetHumanoid, false))
-        {
-            return;
-        }
-
-        targetHumanoid.Species = sourceHumanoid.Species;
-        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
-        targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
-        targetHumanoid.EyeGlowing = sourceHumanoid.EyeGlowing; //starlight
-        targetHumanoid.Age = sourceHumanoid.Age;
-        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
-        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
-        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
-
-        targetHumanoid.Gender = sourceHumanoid.Gender;
-        if (TryComp<GrammarComponent>(target, out var grammar))
-        {
-            grammar.Gender = sourceHumanoid.Gender;
-        }
-        Dirty(target, targetHumanoid);
-    }
-
     /// <summary>
     ///     Removes a marking from a humanoid by ID.
     /// </summary>

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Movement.Systems; // HardLight
 using Content.Shared.Players;
+using Content.Shared.Preferences; // HardLight
 using Content.Shared.Roles;
 using Content.Shared.Traits;
 using Content.Shared.Whitelist;
@@ -111,9 +112,37 @@ public sealed class TraitSystem : EntitySystem
     }
 
     /// <summary>
+    /// HardLight: Applies the selected traits from a humanoid profile to an existing entity.
+    /// This is intended for non-standard spawn paths like admin spawning or cloning
+    /// that already have a validated profile and just need its trait components replayed.
+    /// </summary>
+    public void ApplyProfileTraits(EntityUid uid, HumanoidCharacterProfile profile, string? playerName = null, bool addTraitGear = true)
+    {
+        var sortedTraits = new List<TraitPrototype>();
+        foreach (var traitId in profile.TraitPreferences)
+        {
+            if (_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+                sortedTraits.Add(traitPrototype);
+        }
+
+        sortedTraits.Sort();
+
+        foreach (var traitPrototype in sortedTraits)
+        {
+            if (traitPrototype.Logins.Count > 0 &&
+                (playerName == null || !traitPrototype.Logins.Contains(playerName)))
+            {
+                continue;
+            }
+
+            AddTrait(uid, traitPrototype, addTraitGear);
+        }
+    }
+
+    /// <summary>
     ///     Adds a single Trait Prototype to an Entity.
     /// </summary>
-    public void AddTrait(EntityUid uid, TraitPrototype traitPrototype)
+    public void AddTrait(EntityUid uid, TraitPrototype traitPrototype, bool addTraitGear = true) // HardLight: Added bool addTraitGear
     {
         // Check whitelist/blacklist
         if (_whitelistSystem.IsWhitelistFail(traitPrototype.Whitelist, uid) ||
@@ -127,7 +156,7 @@ public sealed class TraitSystem : EntitySystem
         _movementSpeed.RefreshMovementSpeedModifiers(uid);
 
         // Add item required by the trait
-        if (traitPrototype.TraitGear != null && TryComp(uid, out HandsComponent? handsComponent))
+        if (addTraitGear && traitPrototype.TraitGear != null && TryComp(uid, out HandsComponent? handsComponent)) // HardLight: Added addTraitGear
         {
             var coords = Transform(uid).Coordinates;
             var inhandEntity = EntityManager.SpawnEntity(traitPrototype.TraitGear, coords);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
As it says.

Fixes cloning with cloning facilities not respecting character traits and custom height parameters. Fixes paradox clones not respecting the target character's traits and custom height parameters. And fixes the admin spawn action not respecting character traits and custom height parameters.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cloning either with a cloning pod or through the paradox clone event now respects the target character's traits and custom height settings.
- fix: Spawning characters through the admin action now respects character traits and custom height settings.
