### PR TITLE
Ignore C# Dev Kit's New Cache Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,6 @@ Resources/MapImages
 # Direnv stuff
 .direnv/
 Resources/Prototypes/Entities/Clothing/OuterClothing/.yml
+
+# C# Dev Kit cache file
+*.lscache


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ports: 
https://github.com/space-wizards/space-station-14/pull/43965

From the original PR:
Starting from C# Dev Kit version 3.20.195 and above, they switch to file based project viewer instead of solution viewer, and they did some caching stuff and output .lscache file next to all .csproj.
