### PR TITLE
Revert shadekin regen trait values to those originally proposed

### DIFF
--- a/Resources/Prototypes/_HL/Traits/shadekin.yml
+++ b/Resources/Prototypes/_HL/Traits/shadekin.yml
@@ -63,6 +63,8 @@
   mutuallyExclusiveTraits:
   - ExtremeShadekinRegeneration
   - PlateletFactories
+  - NaturalRegen
+  - UnnaturalRegen
   requirements:
   - !type:TraitsRequirement
     traits:
@@ -96,6 +98,8 @@
   - ShadekinRegeneration
   - PlateletFactories
   - LightSensitivity
+  - NaturalRegen
+  - UnnaturalRegen
   requirements:
   - !type:TraitsRequirement
     traits:

--- a/Resources/Prototypes/_HL/Traits/shadekin.yml
+++ b/Resources/Prototypes/_HL/Traits/shadekin.yml
@@ -55,7 +55,7 @@
   name: hl-trait-shadekin-regeneration-name
   description: hl-trait-shadekin-regeneration-desc
   category: Physical
-  cost: 5
+  cost: 2
   replaceComponents: true
   whitelist:
     components:
@@ -70,7 +70,7 @@
     - ExtremeLightSensitivity
   components:
   - type: ShadekinRegeneration
-    healPerSecond: 0.08
+    healPerSecond: 0.18
     intervalSeconds: 1
     critMultiplier: 0.5
     healTypes:
@@ -87,7 +87,7 @@
   name: hl-trait-extreme-shadekin-regeneration-name
   description: hl-trait-extreme-shadekin-regeneration-desc
   category: Physical
-  cost: 10
+  cost: 5
   replaceComponents: true
   whitelist:
     components:
@@ -102,7 +102,7 @@
     - ExtremeLightSensitivity
   components:
   - type: ShadekinRegeneration
-    healPerSecond: 0.24
+    healPerSecond: 0.36
     intervalSeconds: 1
     critMultiplier: 0.5
     healTypes:


### PR DESCRIPTION
When IngvarJackal first PRd their shadekin regeneration traits, Fenn changed the values before merging. The primary problem is that the values Fenn chose have made the traits entirely useless - they're objectively worse than standard regen traits in every way, so there is absolutely no reason to choose them over the usual ones (such as platelets)

I want to note for any skimming over this that these are traits, not the basic regeneration values for shadekin overall.

## About the PR
- Reverts trait healing to original values (0.18 for basic trait, 0.36 for extreme trait).
- Lowers costs to original values, to be in-line with prerequisite light sensitivity traits (2 for basic, 5 for extreme).
- Makes both traits mutually exclusive with Natural Regen and Unnatural Regen traits, instead of just platelets (bugfix, I feel).
- Does **NOT** revert proposed changes to base shadekin species healing. Those changes fall outside the scope of this PR, and are a balance change I do not wish to challenge.

## Why / Balance
As it stands, the traits have the same costs as existing healing traits, but heal slower, only work in **complete** darkness, and require negative traits in order to be selected. There is absolutely no reason to pick either of them over literally any other healing trait.
I'll also refer to one of Ingvar's reasons - "Light sensitivity and regeneration mechanics should nudge shadekin players to be mechanically incentivised to stick around dimmer areas, which plays well with the lore and natural night vision."

This changed implementation means that:
- The traits are cheaper than alternatives (costing the same as their negative requirements, for a net-0 point cost)
- The traits heal a bit more than alternatives
- The downsides of the traits (only working in complete darkness, requiring light sensitivity traits, being mutually exclusive with other regen traits) remain

## Technical details
- Changes shadekin regeneration trait cost from 5 to 2, and healPerSecond from 0.08 to 0.18
- Changes extreme shadekin regeneration trait cost from 10 to 5, and healPerSecond from 0.24 to 0.36

## How to test
- Look at traits
- See changed cost
- See they're mutually exclusive with others
- Load into game with trait active
- Damage self
- Go to complete darkness
- See faster healing

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Reverts shadekin regeneration trait values to those proposed in initial PR
- fix: Makes shadekin regeneration traits mutually exclusive with all other regen traits, not just platelets