### PR TITLE
Reduces range of nullphase light effect

### DIFF
--- a/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
@@ -136,7 +136,7 @@ public sealed class EtherealPhaseSystem : EntitySystem
         {
             if (HasComp<ShadekinComponent>(uid))
             {
-                var lightQuery = _lookup.GetEntitiesInRange(uid, 5, flags: LookupFlags.StaticSundries)
+                var lightQuery = _lookup.GetEntitiesInRange(uid, 3, flags: LookupFlags.StaticSundries)
                     .Where(x => HasComp<PoweredLightComponent>(x));
                 foreach (var light in lightQuery)
                     _ghost.DoGhostBooEvent(light);
@@ -173,7 +173,7 @@ public sealed class EtherealPhaseSystem : EntitySystem
 
             if (HasComp<ShadekinComponent>(uid))
             {
-                var lightQuery = _lookup.GetEntitiesInRange(uid, 5, flags: LookupFlags.StaticSundries)
+                var lightQuery = _lookup.GetEntitiesInRange(uid, 3, flags: LookupFlags.StaticSundries)
                     .Where(x => HasComp<PoweredLightComponent>(x));
                 foreach (var light in lightQuery)
                     _ghost.DoGhostBooEvent(light);


### PR DESCRIPTION

## About the PR
Does exactly what it says on the tin
When an entity uses the nullphase ability (mainly anomaly role), it causes a ghost-style light flicker effect in the nearby area. This is widely considered to be incredibly damn annoying, especially in areas with a lot of lights.
Whilst I'm sure many would be happy for that functionality to be removed entirely, I feel it exists for a reason, so I opted to just reduce it a bit instead.

## Why / Balance
Lights flickering is always annoying. All lights in a 5-tile radius of any given brighteyes is **especially** annoying. 3 Tiles keeps the effect noticeable whilst hopefully removing a lot of noise, and reducing just how much of an annoyance it is

## Technical details
Changes the range of entities checked by lightQuery var to 3 instead of 5 (checks everything within 3 tiles from origin instead of 5 tiles from origin)

## How to test
- Load as anomaly, or give self NullPhase component
- Phase Shift and see which lights flicker
- Move closer/farther from lights to see when exactly they get affected

## Media
N/A

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Reduced range of phase shift light flickering by 40%
