### PR TITLE
Fix Dualetta Ammo Type + TC Price & Holo-cigar TC Price

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Briefcases/briefcase.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Briefcases/briefcase.yml
@@ -13,8 +13,8 @@
     contents:
       - id: WeaponPistolDualetta
       - id: WeaponPistolDualetta
-      - id: MagazinePistolHighCapacity
-      - id: MagazinePistolHighCapacity
+      - id: Magazine9x19mmPistolHighCapacityFMJ # HardLight: MagazinePistolHighCapacity<Magazine9x19mmPistolHighCapacityFMJ
+      - id: Magazine9x19mmPistolHighCapacityFMJ # HardLight: MagazinePistolHighCapacity<Magazine9x19mmPistolHighCapacityFMJ
       - id: ClothingHandsGlovesCombat
       - id: ClothingUniformJumpsuitDetectiveGrey
       - id: ClothingOuterCoatDetectiveLoadout

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -27,7 +27,7 @@
   icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Pistols/dualetta.rsi, state: icon }
   productEntity: BriefcaseSyndieDualettaBundleFilled
   cost:
-    Telecrystal: 50
+    Telecrystal: 10 # HardLight: 50<10
   categories:
   - UplinkWeaponry
 
@@ -38,7 +38,7 @@
   icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Pistols/dualetta.rsi, state: icon }
   productEntity: BoxDualettaKit
   cost:
-    Telecrystal: 30
+    Telecrystal: 6 # HardLight: 30<6
   categories:
   - UplinkWeaponry
 
@@ -122,7 +122,7 @@
   description: uplink-holo-cigar-desc
   productEntity: HoloCigar
   cost:
-    Telecrystal: 35
+    Telecrystal: 7 # HardLight: 35<7
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -31,22 +31,22 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistolHighCapacity
+        startingItem: Magazine9x19mmPistolHighCapacityFMJ # HardLight: MagazinePistolHighCapacity<Magazine9x19mmPistolHighCapacityFMJ
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2
         whitelist:
           tags:
-          - MagazinePistol
-          - MagazinePistolHighCapacity
+          - Magazine9x19mmPistolFMJ # HardLight: MagazinePistol<Magazine9x19mmPistolFMJ
+          - Magazine9x19mmPistolHighCapacityFMJ # HardLight: MagazinePistolHighCapacity<Magazine9x19mmPistolHighCapacityFMJ
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistol
+        startingItem: Cartridge9x19mmFMJ # HardLight: CartridgePistol<Cartridge9x19mmFMJ
         priority: 1
         whitelist:
           tags:
-          - CartridgePistol
+          - Cartridge9x19mmFMJ # HardLight: CartridgePistol<Cartridge9x19mmFMJ
   - type: Tag
     tags:
     - WeaponPistolDualetta


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes:
#1825

Apparently I hate HardLight and want everyone to eat shit and die, so because I hate it so fucking much, here's yet another bug fix.

Changes the Dualetta's ammo/magazine type from .35 to 9x19mm, the TC price for the kit and bundle from 30 and 50 respectively to 6 and 10.
Changes the Holo-cigar's TC price from 35 to 7 TC.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I simply hate HardLight so fucking much.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
My fragile fucking ego.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed the Dualetta Kit from 30 TC down to 6 TC.
- tweak: Changed the Dualetta Bundle from 50 TC down to 10 TC.
- tweak: Changed the Holo-cigar from 35 TC down to 7 TC.
- fix: Changed the Dualetta to the 9x19 ammo type.
