### PR TITLE
add components which shouldn't be stripped for ever by nullphasing action

### DIFF
--- a/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
@@ -41,6 +41,14 @@ public sealed class EtherealSystem : SharedEtherealSystem
 
     private static readonly SoundPathSpecifier NullSpaceCutoffSound = new("/Audio/_HL/Effects/ma cutoff.ogg");
 
+    // Components that null phase adds and removes; types already present before entry are preserved on exit.
+    private static readonly Type[] NullPhaseComponents =
+    [
+        typeof(StealthComponent),
+        typeof(PressureImmunityComponent),
+        typeof(MovementIgnoreGravityComponent),
+    ];
+
     [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
     [Dependency] private readonly SharedStealthSystem _stealth = default!;
     [Dependency] private readonly EyeSystem _eye = default!;
@@ -89,6 +97,10 @@ public sealed class EtherealSystem : SharedEtherealSystem
 
         if (TryComp<TemperatureComponent>(uid, out var temp))
             temp.AtmosTemperatureTransferEfficiency = 0;
+
+        foreach (var type in NullPhaseComponents)
+            if (EntityManager.HasComponent(uid, type))
+                component.PreExistingComponents.Add(type);
 
         var stealth = EnsureComp<StealthComponent>(uid);
         _stealth.SetVisibility(uid, 0.8f, stealth);
@@ -152,9 +164,9 @@ public sealed class EtherealSystem : SharedEtherealSystem
 
         SuppressFactions(uid, component, false);
 
-        RemComp<StealthComponent>(uid);
-        RemComp<PressureImmunityComponent>(uid);
-        RemComp<MovementIgnoreGravityComponent>(uid);
+        foreach (var type in NullPhaseComponents)
+            if (!component.PreExistingComponents.Contains(type))
+                EntityManager.RemoveComponent(uid, type);
 
         if (TryComp<PullableComponent>(uid, out var pullable) && pullable.BeingPulled)
         {

--- a/Content.Shared/_Starlight/NullSpace/NullSpaceComponent.cs
+++ b/Content.Shared/_Starlight/NullSpace/NullSpaceComponent.cs
@@ -8,4 +8,8 @@ namespace Content.Shared._Starlight.NullSpace;
 public sealed partial class NullSpaceComponent : Component
 {
     public List<ProtoId<NpcFactionPrototype>> SuppressedFactions = new();
+
+    // Component types that were already on the entity before null phase entry;
+    // these are not removed on exit so genetics-granted components are preserved.
+    public HashSet<Type> PreExistingComponents = new();
 }


### PR DESCRIPTION
## About the PR
Nullphasing doesn't strip 
 - StealthComponent
 - PressureImmunityComponent
 - MovementIgnoreGravityComponent

forever any more. They are returned on return to realspace.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
It's a bug which prevents genetics (and who knows which other systems) to work.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nullphase doesn't strip pressure immunity