### PR TITLE
The Freelancer Antagonist Situation (is crazy)

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -104,6 +104,12 @@
     # Anomaly players cannot be targeted.
     - !type:JobMindFilter
       job: Anomaly
+    # HardLight start: Freelancers should not roll as personal targets, as it's consistently impossible to actually track them down.
+    - !type:JobMindFilter
+      job: Mercenary
+    - !type:JobMindFilter
+      job: MercenaryInterview
+    # HardLight end
     # Can't have multiple objectives to kill the same person.
     - !type:TargetObjectiveMindFilter
       blacklist:

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/mercenary.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/mercenary.yml
@@ -2,6 +2,7 @@
   id: Mercenary
   name: job-name-mercenary
   description: job-description-mercenary
+  canBeAntag: false # HardLight
   playTimeTracker: JobMercenary
   startingGear: MercenaryGear
   icon: "JobIconMercenary"
@@ -21,6 +22,7 @@
   id: MercenaryInterview
   name: job-name-mercenary-interview
   description: job-mercenary-pilot
+  canBeAntag: false # HardLight
   playTimeTracker: JobMercenaryInterview
   setPreference: false
   startingGear: MercenaryHologramGear

--- a/Resources/Prototypes/_StarLight/Objectives/traitor.yml
+++ b/Resources/Prototypes/_StarLight/Objectives/traitor.yml
@@ -19,6 +19,12 @@
       # Shadekins (Anomaly role) cannot be targeted - they are not standard crew.
       - !type:JobMindFilter
         job: Anomaly
+      # HardLight start: Freelancers should not roll as personal targets, as it's consistently impossible to actually track them down.
+      - !type:JobMindFilter
+        job: Mercenary
+      - !type:JobMindFilter
+        job: MercenaryInterview
+      # HardLight end
 
 - type: entity
   parent: [BaseTraitorObjective, BaseTeachALessonObjective]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Does two things. First, it prevents Freelancers from being targeted as Syndicate Agent/Sleeper Agent objectives. Second, it prevents Freelancers themselves from being able to roll antagonist roles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Freelancers don't turn on coords. It's impossible to conveniently, consistently figure out what shuttle belongs to a Freelancer, where that shuttle is, and then to reach that shuttle without it disappearing to who the fuck knows where at this point. I've seen a lot of complaints of people playing as these roles and simply not being able to find Freelancer targets.

And this fixes it.

Additionally, Freelancers are typically, consistently over-geared, meaning any objective they could possible get, inverse to having a Freelancer as an objective target, can be done with little actual effort. Need to kill someone? Most Freelancers are as heavily equipped as an entire Nuclear Operative squad, if not more so. Need to steal something? Jaws of Death, emags, access breakers.

It's not fair for people playing station roles, that require antagonists to make their rounds a little more interesting, which is exactly what antagonists EXIST for, to lose that because a Freelancer NRP insta-completed their objectives, or IS their objective, meaning not only would they most likely have to leave the station, which already doesn't really make sense, but they would also have to FIND their target IN SPACE.

It's stupid that Freelancers could even be antagonists/antagonist objectives in the first place.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Ideally, the station.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Freelancers can no longer be targeted for Syndicate Agent/Sleeper Agent objectives.
- remove: Freelancers can no longer be targeted for antagonist roles.
