### PR TITLE
The Evacuation Situation (is crazy)

### DIFF
--- a/Content.Server/Objectives/Systems/EscapeShuttleConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/EscapeShuttleConditionSystem.cs
@@ -1,14 +1,18 @@
 using Content.Server.Objectives.Components;
 using Content.Server.Shuttles.Systems;
+using Content.Shared.CCVar; // HardLight
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
+using Robust.Shared.Configuration; // HardLight
 
 namespace Content.Server.Objectives.Systems;
 
 public sealed class EscapeShuttleConditionSystem : EntitySystem
 {
+    [Dependency] private readonly RoundEndArrivalSystem _arrival = default!; // HardLight
     [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!; // HardLight
     [Dependency] private readonly SharedMindSystem _mind = default!;
 
     public override void Initialize()
@@ -33,7 +37,12 @@ public sealed class EscapeShuttleConditionSystem : EntitySystem
         if (TryComp<CuffableComponent>(mind.OwnedEntity, out var cuffed) && cuffed.CuffedHandCount > 0)
             return 0f;
 
-        // Any emergency shuttle counts for this objective, but not pods.
-        return _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) ? 1f : 0f;
+        // HardLight: If evac is disabled, surviving alive and uncuffed is enough.
+        if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled))
+            return 1f;
+
+        // HardLight: Reaching ColComm now resolves on the round-end destination rather than
+        // whether the player physically boarded the evac shuttle.
+        return _emergencyShuttle.ShuttlesLeft && _arrival.CountsAsArrived(mind.OwnedEntity.Value) ? 1f : 0f;
     }
 }

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Server.Objectives.Systems;
 /// </summary>
 public sealed class KillPersonConditionSystem : EntitySystem
 {
+    [Dependency] private readonly RoundEndArrivalSystem _arrival = default!; // HardLight
     [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
@@ -39,7 +40,6 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 1f;
 
         var targetDead = _mind.IsCharacterDeadIc(mind);
-        var targetOnShuttle = _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value);
         if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled) && requireMaroon)
         {
             requireDead = true;
@@ -49,17 +49,23 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (requireDead && !targetDead)
             return 0f;
 
-        // Always failed if the target needs to be marooned and the shuttle hasn't even arrived yet
-        if (requireMaroon && !_emergencyShuttle.EmergencyShuttleArrived)
-            return 0f;
-
-        // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
+        // HardLight start
+        // Maroon-style objectives now resolve on the target's round-end survival state
+        // rather than whether they physically boarded the evac shuttle.
+        // HardLight end
         if (requireMaroon && !_emergencyShuttle.ShuttlesLeft)
-            return targetOnShuttle ? 0f : 0.5f;
+            return targetDead ? 0.5f : 0f; // HardLight: targetOnShuttle<targetDead
 
-        // If the shuttle has already left, and the target isn't on it, 100%
+        // HardLight start
+        // Once the round has actually ended, only targets that actually ended up
+        // at a safe arrival destination count as having made it.
+        // HardLight end
         if (requireMaroon && _emergencyShuttle.ShuttlesLeft)
-            return targetOnShuttle ? 0f : 1f;
+            return targetDead || !_arrival.CountsAsArrived(mind.OwnedEntity.Value) ? 1f : 0f; // HardLight
+
+        // HardLight: If evac is disabled, requireMaroon is normalized away above.
+        if (requireMaroon)
+            return 0f;
 
         return 1f; // Good job you did it woohoo
     }

--- a/Content.Server/Objectives/Systems/RoundEndArrivalSystem.cs
+++ b/Content.Server/Objectives/Systems/RoundEndArrivalSystem.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Shuttles.Components;
+using Content.Server.Salvage.Expeditions;
+using Content.Server.Shuttles.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.Objectives.Systems;
+
+/// <summary>
+/// Shared helper for objective systems that need to answer
+/// "does this entity count as having made it to safety at round end?"
+/// without caring about which transport path got them there.
+/// </summary>
+public sealed class RoundEndArrivalSystem : EntitySystem
+{
+    [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    /// <summary>
+    /// Returns true if the entity is on ColComm or on an active expedition map.
+    /// This intentionally ignores whether they used evac, a private shuttle, or a portal.
+    /// </summary>
+    public bool CountsAsArrived(EntityUid entity)
+    {
+        var xform = Transform(entity);
+        var mapUid = xform.MapUid;
+        if (mapUid == null)
+            return false;
+
+        if (_emergencyShuttle.IsColcommMap(mapUid.Value))
+            return true;
+
+        if (HasComp<SalvageExpeditionComponent>(mapUid.Value))
+            return true;
+
+        // End-round owned/transit shuttles are queued to FTL to ColComm before
+        // objective resolution runs. Count passengers on those grids as arrived
+        // even if the map transition has not completed yet.
+        if (xform.GridUid != null &&
+            TryComp<FTLComponent>(xform.GridUid.Value, out var ftl) &&
+            _emergencyShuttle.IsColcommMap(GetTargetMap(ftl.TargetCoordinates)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private EntityUid GetTargetMap(EntityCoordinates coordinates)
+    {
+        var mapId = _transform.GetMapId(coordinates);
+        return _transform.GetMap(coordinates) ?? _mapManager.GetMapEntityId(mapId);
+    }
+}

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -642,6 +642,25 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         return maps;
     }
 
+    /// <summary>
+    /// HardLight: Returns true if the provided map is one of the active ColComm maps.
+    /// This avoids per-call set allocations for common objective checks.
+    /// </summary>
+    public bool IsColcommMap(EntityUid mapUid)
+    {
+        if (_singletonColcommMap == mapUid)
+            return true;
+
+        var query = AllEntityQuery<StationColcommComponent>();
+        while (query.MoveNext(out var comp))
+        {
+            if (comp.MapEntity == mapUid)
+                return true;
+        }
+
+        return false;
+    }
+
     private void AddEmergencyShuttle(Entity<StationEmergencyShuttleComponent?, StationColcommComponent?> ent)
     {
         if (!Resolve(ent.Owner, ref ent.Comp1, ref ent.Comp2))


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes it so that arriving at ColComm counts... as arriving at ColComm for Syndicate objectives.

Specifically, alternative means to the evac shuttle now count towards the objective. Private shuttles, the portal, even expeditions, in addition to the evac shuttle still, now function as viable ways to arrive at ColComm.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's just... kind of dumb that it didn't work this way. It doesn't in any other server that I know of, but we also have ColSec. It's not like someone NOT on the evac shuttle couldn't be apprehended. It also prevents SEC from using their own shuttles to escort prisoners, or anyone unable to evacuate normally (i.e. another fucking tesloose) from being considered dead by the Syndicate.

## Technical details
<!-- Summary of code changes for easier review. -->
Straightforward. Simply makes ColComm itself, shuttles queued to FTL to ColComm by the round-end logic, and expedition maps count as having arrived at ColComm.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Do any of the above.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: FTL with private shuttles, in addition to being on expedition maps/the ColComm map, all now count towards "arrived at ColComm" objectives, meaning the evac shuttle is no longer the only official way to arrive at ColComm.
