### PR TITLE
Addressing the Evacuation Allegations

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -17,6 +17,17 @@ public sealed partial class DockingSystem
      */
 
     private const int DockRoundingDigits = 2;
+    private const float DockingAngleKeyPrecision = 10000f; // HardLight
+
+    // HardLight: Many dock pairs on multi-port strips collapse to the exact same final shuttle placement.
+    // Cache those placements during a search so we don't recompute the same collision /
+    // aggregation work over and over.
+    private readonly record struct DockingPlacementKey(
+        float Left,
+        float Right,
+        float Top,
+        float Bottom,
+        int AngleKey);
 
     public Angle GetAngle(EntityUid uid, TransformComponent xform, EntityUid targetUid, TransformComponent targetXform)
     {
@@ -351,6 +362,7 @@ public sealed partial class DockingSystem
         var isMap = HasComp<MapComponent>(targetGrid);
 
         var grids = new List<Entity<MapGridComponent>>();
+        var seenPlacements = new HashSet<DockingPlacementKey>(); // HardLight
         if (shuttleDocks.Count > 0)
         {
             // We'll try all combinations of shuttle docks and see which one is most suitable
@@ -387,6 +399,19 @@ public sealed partial class DockingSystem
                         continue;
                     }
 
+                    // HardLight start
+                    dockedAABB = dockedAABB.Rounded(DockRoundingDigits);
+                    var placementKey = new DockingPlacementKey(
+                        dockedAABB.Left,
+                        dockedAABB.Right,
+                        dockedAABB.Top,
+                        dockedAABB.Bottom,
+                        (int) Math.Round(targetAngle.Reduced().Theta * DockingAngleKeyPrecision));
+
+                    if (!seenPlacements.Add(placementKey))
+                        continue;
+                    // HardLight end
+
                     // Can't just use the AABB as we want to get bounds as tight as possible.
                     var gridPosition = new EntityCoordinates(targetGrid, Vector2.Transform(Vector2.Zero, matty));
                     var spawnPosition = new EntityCoordinates(targetGridXform.MapUid!.Value, _transform.ToMapCoordinates(gridPosition).Position);
@@ -410,8 +435,6 @@ public sealed partial class DockingSystem
                    {
                        (dockUid, gridDockUid, shuttleDock, gridDock),
                    };
-
-                    dockedAABB = dockedAABB.Rounded(DockRoundingDigits);
 
                     foreach (var (otherUid, other) in shuttleDocks)
                     {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -173,8 +173,8 @@ public sealed partial class EmergencyShuttleSystem
 
                 if (!Deleted(Colcomm.Entity))
                 {
-                    _shuttle.FTLToDock(comp.EmergencyShuttle.Value, shuttle,
-                        Colcomm.Entity.Value, _consoleAccumulator, TransitTime);
+                    QueueEmergencyFTLToDock(comp.EmergencyShuttle.Value, shuttle, // HardLight: _shuttle.FTLToDock<QueueEmergencyFTLToDock
+                        Colcomm.Entity.Value, _consoleAccumulator, TransitTime, DockTag); // HardLight: Added DockTag
                     continue;
                 }
 
@@ -211,7 +211,7 @@ public sealed partial class EmergencyShuttleSystem
             }
 
             // Don't dock them. If you do end up doing this then stagger launch.
-            _shuttle.FTLToDock(uid, shuttle, Colcomm.Entity.Value, hyperspaceTime: TransitTime);
+            QueueEmergencyFTLToDock(uid, shuttle, Colcomm.Entity.Value, hyperspaceTime: TransitTime, priorityTag: DockTag); // HardLight: _shuttle.FTLToDock<QueueEmergencyFTLToDock; Added priorityTag: DockTag
             RemCompDeferred<EscapePodComponent>(uid);
         }
 

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -39,6 +39,8 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.DeviceNetwork.Components;
 using Robust.Shared.Prototypes;
+using Content.Shared.HL.CCVar; // HardLight
+using System.Diagnostics.CodeAnalysis; // HardLight
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -260,7 +262,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         if (targetGrid == null)
             return;
 
-        var config = _dock.GetDockingConfig(stationShuttle.EmergencyShuttle.Value, targetGrid.Value, DockTag);
+        var config = GetEmergencyDockingConfig(stationShuttle.EmergencyShuttle.Value, targetGrid.Value, DockTag); // HardLight: _dock.GetDockingConfig<GetEmergencyDockingConfig
         if (config == null)
             return;
 
@@ -363,7 +365,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         }
 
         ShuttleDockResultType resultType;
-        if (_shuttle.TryFTLDock(stationShuttle.EmergencyShuttle.Value, shuttle, targetGrid.Value, out var config, DockTag))
+        if (TryEmergencyFTLDock(stationShuttle.EmergencyShuttle.Value, shuttle, targetGrid.Value, out var config, DockTag)) // HardLight: _shuttle.TryFTLDock<TryEmergencyFTLDock
         {
             _logger.Add(
                 LogType.EmergencyShuttle,
@@ -392,6 +394,70 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             TargetGrid = targetGrid,
         };
     }
+
+    // HardLight start
+    // Use the capped docking-config lookup on evac paths so station/ColComm searches
+    // preserve DockEmergency priority, keep the full-search fallback on capped misses, and avoid
+    // paying the worst-case dock-pair scan on the common path.
+    private DockingConfig? GetEmergencyDockingConfig(EntityUid shuttleUid, EntityUid targetGrid, string? priorityTag = null)
+    {
+        if (!_configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapEnabled))
+            return _dock.GetDockingConfig(shuttleUid, targetGrid, priorityTag);
+
+        var maxShuttleDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapShuttle);
+        var maxGridDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapGrid);
+        return _dock.GetDockingConfig(shuttleUid, targetGrid, priorityTag, DockType.Airlock, maxShuttleDocks, maxGridDocks);
+    }
+
+    private bool TryEmergencyFTLDock(
+        EntityUid shuttleUid,
+        ShuttleComponent shuttle,
+        EntityUid targetGrid,
+        [NotNullWhen(true)] out DockingConfig? config,
+        string? priorityTag = null)
+    {
+        if (!_configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapEnabled))
+            return _shuttle.TryFTLDock(shuttleUid, shuttle, targetGrid, out config, priorityTag);
+
+        var maxShuttleDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapShuttle);
+        var maxGridDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapGrid);
+        return _shuttle.TryFTLDock(
+            shuttleUid,
+            shuttle,
+            targetGrid,
+            out config,
+            maxShuttleDocks,
+            maxGridDocks,
+            priorityTag);
+    }
+
+    private void QueueEmergencyFTLToDock(
+        EntityUid shuttleUid,
+        ShuttleComponent shuttle,
+        EntityUid targetGrid,
+        float? startupTime = null,
+        float? hyperspaceTime = null,
+        string? priorityTag = null)
+    {
+        if (!_configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapEnabled))
+        {
+            _shuttle.FTLToDock(shuttleUid, shuttle, targetGrid, startupTime, hyperspaceTime, priorityTag);
+            return;
+        }
+
+        var maxShuttleDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapShuttle);
+        var maxGridDocks = _configManager.GetCVar(HLCCVars.EmergencyShuttleDockCapGrid);
+        _shuttle.FTLToDock(
+            shuttleUid,
+            shuttle,
+            targetGrid,
+            maxShuttleDocks,
+            maxGridDocks,
+            startupTime,
+            hyperspaceTime,
+            priorityTag);
+    }
+    // HardLight end
 
     /// <summary>
     /// Do post-shuttle-dock setup. Announce to the crew and set up shuttle timers.

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -362,6 +362,62 @@ public sealed partial class ShuttleSystem
         }
     }
 
+    /// <summary>
+    /// HardLight: Moves a shuttle from its current position to docked on the target one, using the capped
+    /// docking-search fast path before falling back to the full search inside docking config lookup.
+    /// If no docks are free when FTLing it will arrive in proximity.
+    /// </summary>
+    public void FTLToDock(
+        EntityUid shuttleUid,
+        ShuttleComponent component,
+        EntityUid target,
+        int maxShuttleDocks,
+        int maxGridDocks,
+        float? startupTime = null,
+        float? hyperspaceTime = null,
+        string? priorityTag = null)
+    {
+        if (!TrySetupFTL(shuttleUid, component, out var hyperspace))
+            return;
+
+        var speedFactor = GetFTLSpeedFactor(shuttleUid);
+        startupTime ??= DefaultStartupTime * speedFactor;
+        hyperspaceTime ??= DefaultTravelTime * speedFactor;
+
+        var config = _dockSystem.GetDockingConfig(
+            shuttleUid,
+            target,
+            priorityTag,
+            DockType.Airlock,
+            maxShuttleDocks,
+            maxGridDocks);
+
+        hyperspace.StartupTime = startupTime.Value;
+        hyperspace.TravelTime = hyperspaceTime.Value;
+        hyperspace.StateTime = StartEndTime.FromStartDuration(
+            _gameTiming.CurTime,
+            TimeSpan.FromSeconds(hyperspace.StartupTime));
+        hyperspace.PriorityTag = priorityTag;
+
+        _console.RefreshShuttleConsoles(shuttleUid);
+
+        if (config != null)
+        {
+            hyperspace.TargetCoordinates = config.Coordinates;
+            hyperspace.TargetAngle = config.Angle;
+        }
+        else if (TryGetFTLProximity(shuttleUid, new EntityCoordinates(target, Vector2.Zero), out var coords, out var targAngle))
+        {
+            hyperspace.TargetCoordinates = coords;
+            hyperspace.TargetAngle = targAngle;
+        }
+        else
+        {
+            hyperspace.TargetCoordinates = Transform(shuttleUid).Coordinates;
+            Log.Error($"Unable to FTL grid {ToPrettyString(shuttleUid)} to target properly?");
+        }
+    }
+
     private bool TrySetupFTL(EntityUid uid, ShuttleComponent shuttle, [NotNullWhen(true)] out FTLComponent? component)
     {
         component = null;
@@ -822,6 +878,42 @@ public sealed partial class ShuttleSystem
         }
 
         var config = _dockSystem.GetDockingConfig(shuttleUid, targetUid, priorityTag, dockType, maxShuttleDocks, maxGridDocks);
+
+        if (config != null)
+        {
+            FTLDock((shuttleUid, shuttleXform), config);
+            return true;
+        }
+
+        TryFTLProximity(shuttleUid, targetUid, shuttleXform, targetXform);
+        return false;
+    }
+
+    /// <summary>
+    /// HardLight: Capped variant of <see cref="TryFTLDock(EntityUid, ShuttleComponent, EntityUid, out DockingConfig?, string?, DockType)"/>
+    /// that still returns the chosen config to the caller.
+    /// </summary>
+    public bool TryFTLDock(
+        EntityUid shuttleUid,
+        ShuttleComponent component,
+        EntityUid targetUid,
+        [NotNullWhen(true)] out DockingConfig? config,
+        int maxShuttleDocks,
+        int maxGridDocks,
+        string? priorityTag = null,
+        DockType dockType = DockType.Airlock)
+    {
+        config = null;
+
+        if (!_xformQuery.TryGetComponent(shuttleUid, out var shuttleXform) ||
+            !_xformQuery.TryGetComponent(targetUid, out var targetXform) ||
+            targetXform.MapUid == null ||
+            !targetXform.MapUid.Value.IsValid())
+        {
+            return false;
+        }
+
+        config = _dockSystem.GetDockingConfig(shuttleUid, targetUid, priorityTag, dockType, maxShuttleDocks, maxGridDocks);
 
         if (config != null)
         {

--- a/Content.Shared/_HL/CCVar/HLCCVars.cs
+++ b/Content.Shared/_HL/CCVar/HLCCVars.cs
@@ -114,6 +114,23 @@ public sealed class HLCCVars
         CVarDef.Create("hardlight.shipyard.purchase_dock_cap_grid", 12, CVar.SERVERONLY,
             desc: "Max station-side docks considered during shipyard purchase docking. <= 0 disables the cap on this side.");
 
+    // HardLight: Emergency shuttle/escape-pod docking-search caps. Evac hits the same pathological
+    // dock-pair search as shipyard purchase, but on a much more player-visible path: once when
+    // the shuttle is called to station and again shortly before launch when it precomputes its
+    // ColComm destination. We preserve priority docks in the capped pass and still fall back to
+    // the full search on miss so this optimization cannot strand the shuttle.
+    public static readonly CVarDef<bool> EmergencyShuttleDockCapEnabled =
+        CVarDef.Create("hardlight.emergency_shuttle.dock_cap_enabled", true, CVar.SERVERONLY,
+            desc: "If true, emergency shuttle and escape pod docking use a capped, spatially spread subset of docks per side before falling back to the full search.");
+
+    public static readonly CVarDef<int> EmergencyShuttleDockCapShuttle =
+        CVarDef.Create("hardlight.emergency_shuttle.dock_cap_shuttle", 8, CVar.SERVERONLY,
+            desc: "Max shuttle-side docks considered during emergency shuttle and escape pod docking. <= 0 disables the cap on this side.");
+
+    public static readonly CVarDef<int> EmergencyShuttleDockCapGrid =
+        CVarDef.Create("hardlight.emergency_shuttle.dock_cap_grid", 12, CVar.SERVERONLY,
+            desc: "Max destination-side docks considered during emergency shuttle and escape pod docking. <= 0 disables the cap on this side.");
+
     /// <summary>
     /// HardLight: number of UseDelay component resets to process per tick during the post-load
     /// sanitize phase of a freshly loaded ship. Set to 0 to disable spreading and do all resets
@@ -143,7 +160,7 @@ public sealed class HLCCVars
     /// </summary>
     public static readonly CVarDef<bool> MechGunOutsideMech =
         CVarDef.Create("mech.gun_outside_mech", false, CVar.SERVERONLY, desc: "If true, allows mech weapons to be used outside of mechs.");
-	
+
     /// <summary>
     /// Starlight: Sends afk players to cryo.
     /// </summary>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Simple fixes to the evac shuttle docking logic and shuttle purchase/load docking logic, aiming to reduce the noticeable freezes when such events fire.

It should no longer lag when the evac shuttle arrives at station, and shuttles spawning in should be a little smoother, as well.

## Technical details
<!-- Summary of code changes for easier review. -->
Optimized emergency shuttle docking to reduce server hitches on evac call and launch by routing evac-specific dock searches through a capped, priority-aware docking path with full fallback to the original search on misses. Also restored DockEmergency priority for the ColComm leg so evac continues to target the intended emergency berths. AND reduced redundant shared docking work by skipping repeated evaluation of identical final shuttle placements in the docking search, improving multi-port dock scenarios without relaxing collision or validity checks.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Dock with me, bro. It's not gay, I swear. I have my socks on.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Evac shuttle arrivals and departures should no longer result in temporary freezes.
- fix: Purchased/loaded ships should result in shorter freezes.
