### PR TITLE
Add some safeguards to prevent nullphasers ending up in walls

### DIFF
--- a/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullPhaseSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Clothing.Components;
 using Content.Shared.Actions;
 using Content.Shared._Starlight.NullSpace;
 using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Robust.Server.GameObjects;
 using Content.Shared.Popups;
 using Content.Shared._Starlight;
@@ -23,6 +24,7 @@ public sealed class EtherealPhaseSystem : EntitySystem
     [Dependency] private readonly GhostSystem _ghost = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
 
     private EntProtoId ShadekinPhaseInEffect = "ShadekinPhaseInEffect";
     private EntProtoId ShadekinPhaseOutEffect = "ShadekinPhaseOutEffect";
@@ -134,6 +136,15 @@ public sealed class EtherealPhaseSystem : EntitySystem
     {
         if (TryComp<NullSpaceComponent>(uid, out var ethereal))
         {
+            var currentTile = _turf.GetTileRef(Transform(uid).Coordinates);
+            // MobMask (not just Impassable) so that windows, shutters, glass airlocks, and anything
+            // else a normal mob cannot walk through also prevents exit — not only solid walls.
+            if (currentTile != null && _turf.IsTileBlocked(currentTile.Value, CollisionGroup.MobMask))
+            {
+                _popup.PopupEntity(Loc.GetString("phase-fail-generic"), uid, uid);
+                return false;
+            }
+
             if (HasComp<ShadekinComponent>(uid))
             {
                 var lightQuery = _lookup.GetEntitiesInRange(uid, 3, flags: LookupFlags.StaticSundries)

--- a/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
@@ -19,6 +19,8 @@ using Content.Server.Hands.Systems;
 using Content.Shared.Stunnable;
 using Content.Shared.Hands.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Robust.Shared.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -26,6 +28,9 @@ using Content.Shared._Starlight;
 using Content.Shared.Actions;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 using Content.Shared.Clothing.Components;
 
 namespace Content.Server._Starlight.NullSpace;
@@ -64,6 +69,10 @@ public sealed class EtherealSystem : SharedEtherealSystem
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly CarryingSystem _carrying = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     private const string HiddenEquipmentContainerId = "nullspace-hidden-equipment";
     private readonly Dictionary<EntityUid, HiddenEquipmentState> _hiddenEquipment = new();
@@ -139,7 +148,14 @@ public sealed class EtherealSystem : SharedEtherealSystem
             if (phaseComp.VoluntaryExit)
                 phaseComp.VoluntaryExit = false;
             else
+            {
                 _actionsSystem.SetIfBiggerCooldown(phaseComp.PhaseAction, TimeSpan.FromSeconds(phaseComp.ForcedEjectionPenalty));
+                TrySlideToFreeTile(uid);
+            }
+        }
+        else
+        {
+            TrySlideToFreeTile(uid);
         }
 
         base.OnShutdown(uid, component, args);
@@ -187,6 +203,49 @@ public sealed class EtherealSystem : SharedEtherealSystem
             RemComp<NullCarryPressureImmunityComponent>(carrying.Carried);
             RemComp<PressureImmunityComponent>(carrying.Carried);
         }
+    }
+
+    private static readonly Vector2i[] AdjacentOffsets =
+    [
+        new(0, 1), new(0, -1), new(1, 0), new(-1, 0),
+        new(1, 1), new(-1, 1), new(1, -1), new(-1, -1),
+    ];
+
+    private void TrySlideToFreeTile(EntityUid uid)
+    {
+        var currentTile = _turf.GetTileRef(Transform(uid).Coordinates);
+        if (currentTile == null)
+            return;
+
+        // MobMask covers everything a normal mob cannot walk through: walls (Impassable),
+        // but also windows, shutters, glass airlocks, half-walls, etc.
+        if (!_turf.IsTileBlocked(currentTile.Value, CollisionGroup.MobMask))
+            return;
+
+        if (!TryComp<MapGridComponent>(currentTile.Value.GridUid, out var grid))
+            return;
+
+        Span<int> indices = stackalloc int[AdjacentOffsets.Length];
+        foreach (var i in ShuffledRange(indices))
+        {
+            var tileIndices = currentTile.Value.GridIndices + AdjacentOffsets[i];
+            if (!_mapSystem.TryGetTileRef(currentTile.Value.GridUid, grid, tileIndices, out var candidate))
+                continue;
+
+            if (!_turf.IsTileBlocked(candidate, CollisionGroup.MobMask))
+            {
+                _transform.SetCoordinates(uid, _turf.GetTileCenter(candidate));
+                return;
+            }
+        }
+    }
+
+    private Span<int> ShuffledRange(Span<int> buffer)
+    {
+        for (var i = 0; i < buffer.Length; i++)
+            buffer[i] = i;
+        _random.Shuffle(buffer);
+        return buffer;
     }
 
     public void SuppressFactions(EntityUid uid, NullSpaceComponent component, bool set)

--- a/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceSystem.cs
@@ -238,6 +238,21 @@ public sealed class EtherealSystem : SharedEtherealSystem
                 return;
             }
         }
+
+        // Second pass: all neighbours were MobMask-blocked (e.g. surrounded by windows/shutters).
+        // Settle for any tile free of solid walls so the entity is at least not geometry-clipping.
+        foreach (var i in indices)
+        {
+            var tileIndices = currentTile.Value.GridIndices + AdjacentOffsets[i];
+            if (!_mapSystem.TryGetTileRef(currentTile.Value.GridUid, grid, tileIndices, out var candidate))
+                continue;
+
+            if (!_turf.IsTileBlocked(candidate, CollisionGroup.Impassable))
+            {
+                _transform.SetCoordinates(uid, _turf.GetTileCenter(candidate));
+                return;
+            }
+        }
     }
 
     private Span<int> ShuffledRange(Span<int> buffer)

--- a/Resources/Locale/en-US/_Starlight/species/shadekin.ftl
+++ b/Resources/Locale/en-US/_Starlight/species/shadekin.ftl
@@ -11,5 +11,5 @@ shadekin-alert-3 = [color=green]Light Exposure: High[/color]
 shadekin-alert-4 = [color=green]Light Exposure:[/color] [color=red]EXTREME[/color]
                     LIGHTS... I NEED DARKNESS! its burns!
 
-phase-fail-generic = I can't phase!
+phase-fail-generic = I can't phase here!
 phase-fail-flasher = I can't phase here — a bluespace flasher is blocking the way!


### PR DESCRIPTION

## About the PR
Prevent willingly phasing out in objects and walls
Try to displace nullphaser on forced exit, onto an adjacent free tile.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
People get stuck in walls and die when hitting nullspace flashers.
Safer exit from nullspace will allow for more aggressive measures against nullspace annoyances (see https://github.com/HardLightSector/HardLight/pull/1857 )
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
1. go into nullspace
2. run along the 1 tile wide wall
3. hit bluespace flahser
4. get displaced not inside the wall
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nullspace dephasing is now safer