### PR TITLE
Small Addition to the YAML Sanitizer

### DIFF
--- a/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
+++ b/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
@@ -133,6 +133,18 @@ public static class ShipSaveYamlSanitizer
         "VendingMachineTankDispenserEVAPOI",
         "VendingMachineVendomatPOI",
         "VendingMachineYouToolPOI",
+        // Syndicate items
+        "ClothingOuterHardsuitSyndieCommander",
+        "ClothingOuterHardsuitJuggernaut",
+        "ClothingOuterArmorRaid",
+        "ClothingHeadHelmetRaid",
+        "WeaponLauncherChinaLake",
+        "WeaponLightMachineGunL6",
+        "BorgModuleL6C",
+        // ColSec items
+        "ClothingOuterHardsuitNfsdExperimental",
+        "WeaponLauncherRocket",
+        "WeaponLauncherRiotGun",
         // Everything else
         "ContainmentField",
         "PortalBlue",

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
@@ -414,25 +414,27 @@
 - type: entity
   parent:
   - BaseExpeditionWeaponTier5
-  - NFWeaponLauncherRocket
+  - WeaponLauncherRocket # HardLight: NFWeaponLauncherRocket<WeaponLauncherRocket
 #  categories: [ HideSpawnMenu ]
   id: NFWeaponLauncherRocketExpedition
+  name: worn RPG-7 # HardLight
 
 - type: entity
   parent:
   - BaseExpeditionWeaponTier5Syndicate
-  - NFWeaponLauncherChinaLake
+  - WeaponLauncherChinaLake # HardLight: NFWeaponLauncherChinaLake<WeaponLauncherChinaLake
 #  categories: [ HideSpawnMenu ]
   id: NFWeaponLauncherChinaLakeExpedition
+  name: worn china lake # HardLight
 
 # LMGs
 - type: entity
   parent:
   - BaseExpeditionWeaponTier5Syndicate
-  - NFWeaponLightMachineGunL6
+  - WeaponLightMachineGunL6 # HardLight: NFWeaponLightMachineGunL6<WeaponLightMachineGunL6
 #  categories: [ HideSpawnMenu ]
   id: NFWeaponLightMachineGunL6Expedition
-  name: worn L6
+  name: worn L6C ROW (762x39mm) # HardLight; worn L6<worn L6C ROW (762x39mm)
 
 # Energy
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
@@ -434,7 +434,7 @@
   - WeaponLightMachineGunL6 # HardLight: NFWeaponLightMachineGunL6<WeaponLightMachineGunL6
 #  categories: [ HideSpawnMenu ]
   id: NFWeaponLightMachineGunL6Expedition
-  name: worn L6C ROW (762x39mm) # HardLight; worn L6<worn L6C ROW (762x39mm)
+  name: worn L6 SAW (762x39mm) # HardLight; worn L6<worn L6 SAW (762x39mm)
 
 # Energy
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds the Syndicate Commander Hardsuit, Cybersun Juggernaut Suit, Raid Suit/Helmet, China Lake, L6 SAW, and the L6C ROW Module to the YAML sanitizer, meaning they will no longer serialize (save) to shuttle ymls. 

Also adds the M92-X Experimental Tacsuit and Riot Gun.

In addition, I also reparented the worn China Lake, worn L6, and worn... RPG-7 to the actual versions of the weapons that HardLight uses. They also have distinct names now.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Direct request from the directorate.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Several pieces of Syndicate/ColSec equipment will no longer save on shuttles.
- fix: If they didn't before, the worn China Lake, L6 SAW, and RPG-7 should now use the correct ammo/magazine types.
