### PR TITLE
Fix Pettable to be 100%, as Velzie intended

### DIFF
--- a/Content.Shared/_HL/Traits/Physical/Systems/SharedPettableInteractionOverrideSystem.cs
+++ b/Content.Shared/_HL/Traits/Physical/Systems/SharedPettableInteractionOverrideSystem.cs
@@ -24,13 +24,13 @@ public sealed class SharedPettableInteractionOverrideSystem : EntitySystem
         var popup = EnsureComp<InteractionPopupComponent>(uid);
         _interactionPopup.ConfigureInteractionPopup(
             (uid, popup),
-            0.75f,
+            1.0F,
             "petting-success-soft-floofy-kitsune",
-            "petting-failure-generic",
+            "petting-success-soft-floofy-kitsune",
             PetSound,
-            null,
+            PetSound,
             "EffectHearts",
-            null,
+            "EffectHearts",
             null,
             true);
     }


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#1177 intended for the success chance to be 100%. #1682 did not, seemingly, inherit that.
As a robust failsafe I also made the failure state the exact same as success.

## Technical details
<!-- Summary of code changes for easier review. -->
One minor change to `SharedPettableInteractionOverrideSystem#OnStartup`.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Get pet :3

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- fix: Pettable trait is now a 100% chance to be pet :3