### PR TITLE
Protogen fixes

### DIFF
--- a/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.UnitTesting;
 
 namespace Content.IntegrationTests.Tests.Preferences
@@ -63,11 +64,12 @@ namespace Content.IntegrationTests.Tests.Preferences
         {
             var cfg = server.ResolveDependency<IConfigurationManager>();
             var opsLog = server.ResolveDependency<ILogManager>().GetSawmill("db.ops");
+            var proto = server.ResolveDependency<IPrototypeManager>();
             var builder = new DbContextOptionsBuilder<SqliteServerDbContext>();
             var conn = new SqliteConnection("Data Source=:memory:");
             conn.Open();
             builder.UseSqlite(conn);
-            return new ServerDbSqlite(() => builder.Options, true, cfg, true, opsLog);
+            return new ServerDbSqlite(() => builder.Options, true, cfg, true, opsLog, proto);
         }
 
         [Test]

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -33,13 +33,16 @@ namespace Content.Server.Database
     public abstract class ServerDbBase
     {
         private readonly ISawmill _opsLog;
+        private readonly IPrototypeManager _prototypeManager;
 
         public event Action<DatabaseNotification>? OnNotificationReceived;
 
         /// <param name="opsLog">Sawmill to trace log database operations to.</param>
-        public ServerDbBase(ISawmill opsLog)
+        /// <param name="prototypeManager">Used for fetching species prototype</param>
+        public ServerDbBase(ISawmill opsLog, IPrototypeManager prototypeManager)
         {
             _opsLog = opsLog;
+            _prototypeManager = prototypeManager;
         }
 
         #region Preferences
@@ -85,7 +88,7 @@ namespace Content.Server.Database
             {
                 try
                 {
-                    profiles[profile.Slot] = ConvertProfiles(profile);
+                    profiles[profile.Slot] = ConvertProfiles(profile, _prototypeManager);
                 }
                 catch (Exception e)
                 {
@@ -243,7 +246,7 @@ namespace Content.Server.Database
             prefs.SelectedCharacterSlot = newSlot;
         }
 
-        private static HumanoidCharacterProfile ConvertProfiles(Profile profile)
+        private static HumanoidCharacterProfile ConvertProfiles(Profile profile, IPrototypeManager prototypeManager)
         {
             var jobs = profile.Jobs.ToDictionary(j => new ProtoId<JobPrototype>(j.JobName), j => (JobPriority) j.Priority);
             var antags = profile.Antags.Select(a => new ProtoId<AntagPrototype>(a.AntagName));
@@ -306,7 +309,6 @@ namespace Content.Server.Database
             if (loadouts.Remove(HumanoidCharacterProfile.SpeciesLoadoutDatabaseKey, out var speciesLoadoutValue))
             {
                 speciesLoadout = speciesLoadoutValue;
-                var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
 
                 // `__species_loadout` is only the DB storage key. Restore the actual role prototype
                 // immediately so later profile validation never indexes the sentinel as a prototype.

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -380,6 +380,7 @@ namespace Content.Server.Database
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IResourceManager _res = default!;
         [Dependency] private readonly ILogManager _logMgr = default!;
+        [Dependency] private readonly IPrototypeManager _proto = default!;
 
         private ServerDbBase _db = default!;
         private LoggingProvider _msLogProvider = default!;
@@ -411,11 +412,11 @@ namespace Content.Server.Database
             {
                 case "sqlite":
                     SetupSqlite(out var contextFunc, out var inMemory);
-                    _db = new ServerDbSqlite(contextFunc, inMemory, _cfg, _synchronous, opsLog);
+                    _db = new ServerDbSqlite(contextFunc, inMemory, _cfg, _synchronous, opsLog, _proto);
                     break;
                 case "postgres":
                     var (pgOptions, conString) = CreatePostgresOptions();
-                    _db = new ServerDbPostgres(pgOptions, conString, _cfg, opsLog, notifyLog);
+                    _db = new ServerDbPostgres(pgOptions, conString, _cfg, opsLog, notifyLog, _proto);
                     break;
                 default:
                     throw new InvalidDataException($"Unknown database engine {engine}.");

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -13,6 +13,7 @@ using Content.Shared.Database;
 using Microsoft.EntityFrameworkCore;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Database
@@ -30,8 +31,9 @@ namespace Content.Server.Database
             string connectionString,
             IConfigurationManager cfg,
             ISawmill opsLog,
-            ISawmill notifyLog)
-            : base(opsLog)
+            ISawmill notifyLog,
+            IPrototypeManager prototypeManager)
+            : base(opsLog, prototypeManager)
         {
             var concurrency = cfg.GetCVar(CCVars.DatabasePgConcurrency);
 

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -13,6 +13,7 @@ using Content.Shared.Database;
 using Microsoft.EntityFrameworkCore;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Database
@@ -36,8 +37,9 @@ namespace Content.Server.Database
             bool inMemory,
             IConfigurationManager cfg,
             bool synchronous,
-            ISawmill opsLog)
-            : base(opsLog)
+            ISawmill opsLog,
+            IPrototypeManager prototypeManager)
+            : base(opsLog, prototypeManager)
         {
             _options = options;
 

--- a/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
@@ -138,6 +138,7 @@
     metabolizerTypes: [Human]
     groups:
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
     - id: Narcotic
   - type: Item
@@ -317,6 +318,7 @@
     metabolizerTypes: [Avali]
     groups:
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
     - id: Narcotic
 
@@ -351,6 +353,7 @@
     metabolizerTypes: [Arachnid]
     groups:
     - id: Medicine
+    - id: Cryogenic
     - id: Poison
     - id: Narcotic
 


### PR DESCRIPTION

## About the PR
This PR fixes two bugs about protogens, one them being literally not able to load, second them not being affected by cryogenics.

## Why / Balance
Its generally good to have working species.

## Technical details
The change made in this PR https://github.com/HardLightSector/HardLight/pull/1789
made it so the protogens tried reaching PrototypeManager from within a static method, which was not accessible there.

As for Cryochems, protogens didn't have Cryogenic metabolizer in their hearts.

## How to test
Enable guest profile saving for your debug environment, and create a protogen character, as you can see, before this fix, we get crashed with a lovely message saying that you cannot reach IoC in the context of a static method.

Its no longer there after the fix.

With cryogenics, inject protogens with lexorin and use cryoxadone on them.

## Media

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Fasuh
- fix: Fixed Protogens not working at all.
- fix: Fixed Cryogenics not working for Protogens
