### PR TITLE
Allow milk to go in the coffee machine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -43,6 +43,9 @@
   - type: TrashOnSolutionEmpty
     solution: drink
   - type: DnaSubstanceTrace
+  - type: Tag # Hardlight / Frontier
+    tags:
+    - DrinkBottle
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -164,9 +167,6 @@
           Quantity: 120 # Coyote: 100 -> 120u
   - type: Sprite
     sprite: Objects/Consumable/Drinks/milk.rsi
-  - type: Tag
-    tags:
-    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
 
 - type: entity
   parent: [RecyclableItemPlasticMedium, DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull] # Frontier: added RecyclableItemPlasticMedium
@@ -182,9 +182,6 @@
           Quantity: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/soymilk.rsi
-  - type: Tag
-    tags:
-    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
 
 - type: entity
   parent: [RecyclableItemPlasticMedium, DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull] # Frontier: added RecyclableItemPlasticMedium
@@ -200,9 +197,6 @@
           Quantity: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/oatmilk.rsi
-  - type: Tag
-    tags:
-    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
     
 - type: entity
   parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseFull]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -164,6 +164,9 @@
           Quantity: 120 # Coyote: 100 -> 120u
   - type: Sprite
     sprite: Objects/Consumable/Drinks/milk.rsi
+  - type: Tag
+    tags:
+    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
 
 - type: entity
   parent: [RecyclableItemPlasticMedium, DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull] # Frontier: added RecyclableItemPlasticMedium
@@ -179,6 +182,9 @@
           Quantity: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/soymilk.rsi
+  - type: Tag
+    tags:
+    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
 
 - type: entity
   parent: [RecyclableItemPlasticMedium, DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull] # Frontier: added RecyclableItemPlasticMedium
@@ -194,6 +200,9 @@
           Quantity: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/oatmilk.rsi
+  - type: Tag
+    tags:
+    - DrinkBottle # Hardlight: Why can't you put milk in the coffee machine...?
     
 - type: entity
   parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseFull]


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Lets you put milk (normal, soy, and oat) in spacepresso machines.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Gestures aggressively to cafe lattes:
<img width="500" height="130" alt="image" src="https://github.com/user-attachments/assets/0ef01398-320a-468e-9dcb-d1a5037801b0" />

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Illumos
- add: Oat, soy, and regular milk bottles are now properly shaped and fit in standard NanoTrasen® NanoCaf™ Machines.
