### PR TITLE
Added Naga tail markings to Oni

### DIFF
--- a/Resources/Prototypes/_HL/Entities/Mobs/Customization/Markings/reptilian.yml
+++ b/Resources/Prototypes/_HL/Entities/Mobs/Customization/Markings/reptilian.yml
@@ -24,7 +24,7 @@
   id: ReptilianTailNaga
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile]
+  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile, Oni]
   sprites:
     - sprite: _HL/Mobs/Customization/Reptilian/naga.rsi
       state: naga_primary
@@ -35,7 +35,7 @@
   id: ReptilianTailNagaStriped
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile]
+  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile, Oni]
   sprites:
     - sprite: _HL/Mobs/Customization/Reptilian/naga.rsi
       state: naga_striped_primary
@@ -48,7 +48,7 @@
   id: ReptilianTailNagaRattlesnake
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile]
+  speciesRestriction: [Skrell, Reptilian, Human, ProtoReptile, Oni]
   sprites:
     - sprite: _HL/Mobs/Customization/Reptilian/naga.rsi
       state: naga_rattlesnake_primary


### PR DESCRIPTION
Oni are just big humans and humans get it. Marking is cosmetic anyway. seems like a fair addition

marking lines up with body correctly in testing

## About the PR
Allowed Oni species to access reptilian tail marking for Naga tail +variant naga tails

## Why / Balance
Non-impactful change for balance
Adds additional options for players, meaning it adds more fun.
Lore wise Oni can come in more forms than just humanoid ogre, and have been depicted with scales. also its funny spacegame and i could make a billion reasons and Oni might end up with snake body

## Technical details
Resources\Prototypes\_HL\Entities\Mobs\Customization\Markings\reptilian.yml
added Oni to speciesrestrictions list for naga markings

## How to test
added marking and spawned oni character. 

looks great.

## Media
<img width="473" height="454" alt="image" src="https://github.com/user-attachments/assets/eda038ca-2e56-4adb-9697-6186757190ac" />

## Breaking changes
None found

**Changelog**
:cl:
- add: allowed Oni to use Naga tail markings
